### PR TITLE
Fix native Windows fallback and Sana provenance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep the vendored source snapshot byte-stable across Git checkouts.
+sol_h3/_vendor/** text eol=lf
+sol_h3/sol_manifest.json text eol=lf
+tools/rectangular_sm120.patch text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,28 @@ jobs:
       - run: python -m pytest -q
         env:
           SANA_PATH: ${{ github.workspace }}/_deps/Sana
+  windows-provenance:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
+      - run: python -m pip install "pytest>=8"
+      - run: pip install -e . --no-deps
+      - run: python -m pip check
+      - name: Verify Windows provenance and fail-closed runtime contracts
+        run: >-
+          python -m pytest -q
+          tests/test_sana_contract.py::test_provenance_and_node_local_imports
+          tests/test_sana_contract.py::test_manifest_names_are_platform_independent
+          tests/test_sana_contract.py::test_git_crlf_checkout_preserves_provenance
+          tests/test_sana_contract.py::test_tampered_source_cannot_claim_verified
+          tests/test_sana_contract.py::test_native_windows_missing_cute_reports_supported_path
+          tests/test_native_execution.py::test_native_windows_exact_fails_closed
   native-interop:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.1.1 — 2026-09-09
+
+Patch release for native-Windows installation/provenance behavior reported in issue #4.
+
+### Fixed
+
+- Uses canonical POSIX manifest keys when verifying the vendored Sana source tree, fixing the Windows `Packaged Sana source file set mismatch` caused by `Path` backslash rendering.
+- Pins vendored source files to LF checkout and accepts only Git-style CRLF-to-LF normalization in addition to exact packaged bytes; arbitrary tampering still fails closed.
+- Adds Windows provenance CI for path semantics, CRLF normalization and tamper rejection.
+- Scopes the CuTe/Triton runtime toolchain dependencies to Linux, matching the supported/validated custom-kernel platforms.
+- Reports the Linux/WSL2 requirement explicitly when native Windows cannot provide the required `cute_sm120` backend.
+- Fails Exact Runtime closed on native Windows before importing/executing the Triton affine kernel and delegates to the untouched native H3 block (`exact:native_windows_unvalidated`).
+- Adds `docs/WINDOWS.md` with the supported-platform boundary and AIMDO isolation procedure.
+
+### Scope and remaining boundary
+
+RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support native Windows. The real SOL `cute_sm120` kernel therefore still requires Linux/WSL2; v0.1.1 does not claim native-Windows SOL acceleration.
+
+The issue #4 v0.1.0 request reached `sparse_calls=0` / `sol_backend=null` and later failed inside `comfy_aimdo.malloc_graph_pop`, while Exact Runtime had executed (`exact_blocks=600`). v0.1.1 does not claim that Sol-H3 caused the AIMDO access violation. Instead, native Windows now automatically runs neither Sol-H3 custom kernel path: SOL falls back dense because CuTe is unavailable and Exact Runtime delegates to native H3. A remaining AIMDO crash after upgrading is therefore separable from Sol-H3 kernel execution.
+
+The Linux/WSL SM120 production kernel contract and previously validated rectangular/VDN/Flow/Spectrum behavior are unchanged.
+
 ## v0.1.0 — 2026-09-09
 
 Initial production-validated release of ComfyUI-Sol-H3.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native MiniMax-H3 exact-runtime optimization and composable Sana Sol-Attn integration for ComfyUI.
 
-**v0.1.0** packages the real Sol-Attn implementation from [`xmarre/Sana`, branch `sol-engine`](https://github.com/xmarre/Sana/tree/2936c47637380842aaa4a4488fac5006cc542b70/models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn), pinned at revision `2936c47637380842aaa4a4488fac5006cc542b70`. On SM120 it executes Sana's CuTe `cute_sm120` backend; `comfy_kitchen.sol_attn` is not substituted for it.
+**v0.1.1** packages the real Sol-Attn implementation from [`xmarre/Sana`, branch `sol-engine`](https://github.com/xmarre/Sana/tree/2936c47637380842aaa4a4488fac5006cc542b70/models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn), pinned at revision `2936c47637380842aaa4a4488fac5006cc542b70`. On supported SM120 Linux/WSL2 systems it executes Sana's CuTe `cute_sm120` backend; `comfy_kitchen.sol_attn` is not substituted for it.
 
 The release has three parts:
 
@@ -11,6 +11,8 @@ The release has three parts:
 - **Composable interoperability** — inherited dense providers, VDN grouped attention, Spectrum backend history, Untwist preprocessing, Diff-Aid and Flow mixed-grid routing can coexist when their ownership contracts are coherent.
 
 Unvalidated combinations are experimental telemetry rather than blanket errors. Hard failures are reserved for broken contracts, unsafe geometry/indexing, failed arithmetic verification or real execution failures.
+
+> **Native Windows:** RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support Windows. The real `cute_sm120` SOL kernel therefore requires Linux/WSL2. v0.1.1 fixes Windows provenance/install diagnostics, falls SOL back to inherited dense attention, and fails Exact Runtime closed to untouched native H3 before its Triton affine kernel can execute. It does not claim native-Windows SOL acceleration. See [Native Windows status](docs/WINDOWS.md).
 
 ## v0.1.0 production status
 
@@ -35,6 +37,8 @@ The real packaged kernel, VDN API-v3 rectangular route, Flow mixed-grid route, S
 ## Nodes and composition
 
 Apply MODEL patches and then apply **Sol-H3 SOL Attention (Experimental)** before sampling. `exact_fusion=true` also requests Exact Runtime. A later **Sol-H3 Exact Runtime** node merges with the same lifecycle rather than installing a second one.
+
+On native Windows, the node can remain in the workflow but both custom-kernel paths fail closed: SOL delegates to inherited dense attention because CuTe is unavailable, and Exact Runtime records `exact:native_windows_unvalidated` then executes the untouched native H3 block. Linux/WSL2 behavior is unchanged.
 
 Supported composition includes Exact -> SOL, SOL -> Exact and repeated identical applications. Different SOL policies on the same MODEL branch are ambiguous and require separate branches.
 
@@ -177,7 +181,7 @@ Interpretation:
 
 - strided CuTe execution is effectively parity with pre-contiguous CuTe (`-0.37%` CUDA / `-0.09%` wall);
 - the old copies add about `0.786 ms` CUDA / `0.761 ms` host wall per representative mixed call;
-- the zero-copy path is about `2.01%` faster than old copy+kernel in CUDA timing and `1.85%` faster in host-wall timing for this isolated call;
+- the zero-copy path is about `2.01%` faster than old copy+kernel in CUDA timing and `1.85%` faster than old copy+kernel in host-wall timing for this isolated call;
 - the old bridge materialized `1,248,522,240` bytes per mixed call. Across 144 representative mixed calls, zero-copy avoids about **167.44 GiB** of redundant Q/V materialization and about **0.11 s** of direct copy overhead.
 
 This is intentionally a **micro-optimization** claim. It does not explain multi-second whole-workflow variance.
@@ -229,9 +233,9 @@ git pull
 python -m pip install -r requirements.txt
 ```
 
-Dependencies are PyTorch, Triton `>=3.6,<4` on Linux, NVIDIA CUTLASS DSL with the CUDA 13 extra, CUDA Python and Apache TVM FFI. No Sana checkout, `SOL_ROOT`, special `PYTHONPATH`, runtime source download or linker override is required.
+On Linux/WSL2, dependencies include PyTorch, Triton `>=3.6,<4`, NVIDIA CUTLASS DSL with the CUDA 13 extra, CUDA Python and Apache TVM FFI. No Sana checkout, `SOL_ROOT`, special `PYTHONPATH`, runtime source download or linker override is required. The custom-kernel runtime dependencies are intentionally not installed on native Windows.
 
-The validated production target is **Linux/WSL on SM120**. Native Windows kernel execution remains unvalidated.
+The validated and supported SOL/Exact custom-kernel target is **Linux/WSL2 on SM120**. Native Windows cannot currently execute the required NVIDIA CuTe DSL backend; SOL falls back locally to inherited dense attention and Exact Runtime delegates to native H3. See [Native Windows status](docs/WINDOWS.md).
 
 ## SageAttention on Blackwell
 
@@ -250,7 +254,7 @@ python -m ruff check .
 python -m pytest -q
 ```
 
-GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md).
+GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows provenance and AIMDO isolation guidance is in [WINDOWS](docs/WINDOWS.md).
 
 Useful counters include:
 
@@ -281,7 +285,7 @@ A successful run with zero sparse calls is valid execution telemetry but is not 
 
 ## Release notes
 
-See [CHANGELOG.md](CHANGELOG.md) for the v0.1.0 release summary and validation boundaries.
+See [CHANGELOG.md](CHANGELOG.md) for the v0.1.1 release summary and validation boundaries.
 
 `sol_h3/sol_manifest.json` records original upstream hashes and packaged hashes. `tools/rectangular_sm120.patch` records the functional rectangular changes after import adaptation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,111 +1,34 @@
-# ComfyUI-Sol-H3 v0.1.0
+# ComfyUI-Sol-H3 v0.1.1
 
-Initial production-validated release of native MiniMax-H3 Exact Runtime and composable Sana Sol-Attn for ComfyUI.
+Patch release addressing the native-Windows failure reported in issue #4 without claiming unsupported native-Windows SOL kernel execution.
 
-## What ships
+## Fixed
 
-- The real Sana Sol-Attn source pinned from `xmarre/Sana` revision `2936c47637380842aaa4a4488fac5006cc542b70`.
-- Real CuTe `cute_sm120` execution on Blackwell SM120.
-- Rectangular attention: `Q [B,Tq,H,128]`, `K/V [B,Tkv,H,128]`.
-- Exact native MiniMax-H3 affine/runtime optimization.
-- VDN provider API v3 with requested-Q-only execution and unchanged restricted K/V semantics.
-- Flow API-2 mixed-grid SOL routing while VDN retains its learned gate.
-- Spectrum numerical-backend history/receipt coordination.
-- Untwist preprocessing exactly once and audited Diff-Aid/Flow replacement composition.
-- Layout-sensitive arithmetic calibration and fail-closed fallback/history behavior.
-- Zero-copy BTHD input handling for suitable strided layouts.
+- Fixed a real cross-platform provenance bug: vendored Sana file names are now compared with canonical `/` manifest paths instead of platform-native `Path` strings. A valid Windows checkout no longer fails every nested entry with `Packaged Sana source file set mismatch`.
+- Pinned the vendored source snapshot to LF checkout via `.gitattributes`.
+- Provenance hashing now accepts only Git-style CRLF-to-LF transport normalization in addition to exact bytes; any other content change still fails closed.
+- Added `windows-latest` provenance CI covering Windows path semantics, CRLF normalization and tamper rejection.
+- Scoped CuTe/Triton runtime dependencies to Linux, matching the platform actually supported by the packaged kernel path.
+- Native Windows now reports an explicit `Linux/WSL2` requirement when the SM120 CuTe backend is unavailable instead of presenting the fallback as a generic backend-selection problem.
+- Exact Runtime now fails closed on native Windows before importing or executing its Triton affine kernel and delegates to the untouched native H3 block. This removes the unvalidated Sol-H3 Exact/Triton path from ComfyUI's native-Windows AIMDO malloc-graph lifecycle.
 
-## Production validation
+## Native Windows boundary
 
-Validated on an **NVIDIA RTX PRO 6000 Blackwell Workstation Edition (SM120)** with PyTorch `2.10.0+cu130` / CUDA 13.0.
+RTX 5090 is SM120 hardware and is architecturally eligible for the packaged kernel. The current NVIDIA CUTLASS CuTe DSL runtime does not support Windows, so the real `cute_sm120` SOL kernel still requires Linux/WSL2. This release fixes Windows installation/provenance behavior and diagnostics; it does **not** claim native-Windows SOL acceleration.
 
-Final Spectrum topology:
+Official NVIDIA references:
 
-```text
-sampler_logical_calls       18
-transformer_actual_nfe      14
-spectrum_forecast_calls      4
+- https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/limitations.html
+- https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/quick_start.html
 
-low:    8 actual / 2 forecast
-high:   4 actual / 2 forecast
-probe:  2 actual / 0 forecast
-```
+See `docs/WINDOWS.md` for the exact boundary and troubleshooting procedure.
 
-The SOL-bypassed control is `13 actual + 5 forecast`; the one additional SOL actual is the intentional initial `dense -> sol` backend transition and remains a safety anchor.
+## Issue #4 allocator crash
 
-VDN API-v3 native routes are 1:1 requested/kernel Q rows with no square expansion:
+The attached failing request reported `sol_backend=null`, `sol_source_tree_verified=false` and `sparse_calls=0`, so no SOL sparse kernel executed before the later `comfy_aimdo` `malloc_graph_pop` access violation. The same v0.1.0 request had `exact_fusion=true` and `exact_blocks=600`, so Exact Runtime was the only Sol-H3 custom kernel path that actually executed.
 
-| Stage | Rectangular SOL calls | Requested Q rows | Kernel Q rows | Square expansion |
-|---|---:|---:|---:|---:|
-| Native low | 1,584 | 3,744,000 | 3,744,000 | 0 |
-| Native high | 1,056 | 4,972,800 | 4,972,800 | 0 |
-| Later native high | 1,248 | 5,967,360 | 5,967,360 | 0 |
+v0.1.1 does not claim that Sol-H3 caused the AIMDO failure. Instead, native Windows now automatically delegates Exact Runtime to native H3, while SOL remains a dense fallback because CuTe is unavailable. If `comfy_aimdo` still fails after upgrading to v0.1.1, the failure is reproducible with both Sol-H3 custom kernel paths absent and should be investigated in the ComfyUI/AIMDO path separately.
 
-The historical VDN v2 compatibility bridge expanded Q work by roughly **4.4–5.4x** in affected stages. API v3 removes that kernel-row expansion without changing VDN's trained attention-domain ownership.
+## Regression scope
 
-Representative Flow mixed-grid route:
-
-```text
-external_mixed_sol_calls           144
-external_mixed_q_rows         6,270,480
-external_mixed_kernel_q_rows  6,270,480
-compatibility_fallbacks              {}
-```
-
-## Zero-copy BTHD result
-
-Exact production mixed layout:
-
-```text
-shape      [1, 43545, 56, 128]
-Q/V stride [7168, 21504, 128, 1]
-K stride   [7168,  7168, 128, 1]
-```
-
-Seven-run isolated real-SM120 medians with identical Q/K/V values:
-
-| Path | CUDA median | Host-wall median |
-|---|---:|---:|
-| strided zero-copy | **46.768 ms** | **42.338 ms** |
-| pre-contiguous kernel | 46.941 ms | 42.376 ms |
-| old copy + kernel | 47.727 ms | 43.136 ms |
-
-The strided kernel is effectively parity with pre-contiguous execution; the historical copies add about `0.786 ms` CUDA / `0.761 ms` wall per representative mixed call. The old bridge materialized `1,248,522,240` bytes per mixed call. Across 144 calls, zero-copy avoids about **167.44 GiB** of redundant Q/V materialization and roughly **0.11 s** of direct copy overhead.
-
-This is a micro-optimization result, not a claim of a large end-to-end speedup.
-
-## Timing evidence
-
-Historical matched Exact-only A/B:
-
-| Exact Runtime | Sampler | End-to-end | Peak VRAM |
-|---|---:|---:|---:|
-| off | 263.56 s | 312.57 s | 17.18 GB |
-| on | **247.30 s** | **298.69 s** | 17.18 GB |
-
-A same-process hot SOL run with the final 14/4 topology measured `274.87 s` end-to-end / `229.13 s` sampler, versus `287.51 s` / `240.55 s` for the 13/5 bypass control. Because NFE count, sparse routing/content and cache state are not a controlled A/B, this release deliberately does **not** convert those figures into a large SOL percentage claim.
-
-## Companion interoperability
-
-The reviewed companion pins are:
-
-```text
-Spectrum #104  9c682c07f4c5ea9de601cda234755a1561b59f59
-Untwist #9     cf428e204f42354ce9a9582dd956906f75a52974
-VDN #8         b6f0755c4172ec5c17386c56998f454e78b2a2d4
-VDN #11        5b63dc670229d419a6350b64f7ceda609dbc8194
-Flow v0.3.2    fe0ef8752b92081b5a85bc9b39ad8e2a7037d591
-Diff-Aid       ba9d9efbcf7e64c755e068cb76547d8cc85481eb
-```
-
-VDN #11 applies after the still-unreleased VDN #8 audio-fidelity overlay, so that integration remains a pinned companion stack rather than a mainline VDN release at the time of Sol-H3 v0.1.0.
-
-## Boundaries
-
-- Production GPU validation is Linux/WSL on SM120; native Windows kernel execution is not yet validated.
-- Only Flow's explicit validated API-2 mixed contract is recognized; arbitrary mixed/external layouts are not inferred.
-- Unknown replacement/history topology fails closed to actual/inherited attention.
-- Optional SageAttention is an inherited dense provider and is not bundled.
-- Successful sparse routing is not by itself a decoded-media quality or whole-workflow speed claim.
-
-See `README.md`, `docs/VALIDATION.md`, `docs/RECTANGULAR.md` and `CHANGELOG.md` for the full implementation and evidence record.
+The Linux/WSL SM120 production kernel contract, rectangular Q/KV execution, VDN API-v3 route, Flow mixed-grid route, Spectrum history semantics and zero-copy BTHD behavior are unchanged from v0.1.0.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,0 +1,56 @@
+# Native Windows status
+
+## SOL attention
+
+RTX 5090 is an SM120 GPU, so the hardware architecture is eligible for the packaged Sana Sol-Attn path. The current NVIDIA CUTLASS CuTe DSL runtime is the limiting component on native Windows: NVIDIA documents Windows support as unsupported and the CuTe DSL quick-start currently lists Linux x86_64/aarch64 as the supported platforms.
+
+For the real `cute_sm120` SOL kernel, use Linux or WSL2. Native Windows is not a supported SOL-kernel execution target in this release. When CuTe is unavailable on native Windows, Sol-H3 falls back locally to the inherited dense attention provider and reports an explicit `native Windows ... requires Linux/WSL2` compatibility reason.
+
+Official NVIDIA references:
+
+- https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/limitations.html
+- https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/quick_start.html
+
+## Exact Runtime
+
+The Exact Runtime affine path uses a Triton kernel. It is production-validated on Linux/WSL, not native Windows. v0.1.1 therefore fails this optimization closed on `sys.platform == "win32"`: `ineligible_reason()` returns `native_windows_unvalidated` before the Triton kernel is imported or executed, and the normal untouched MiniMax-H3 block runs instead.
+
+This is intentional. A third-party native-Windows Triton build plus ComfyUI's AIMDO malloc-graph compiler is not an execution contract validated by this project. WSL2/Linux continues to use the existing Exact Runtime path unchanged.
+
+## Issue #4: `Packaged Sana source file set mismatch`
+
+The original v0.1.0 provenance verifier used `str(Path.relative_to(...))` to compare on-disk vendored paths with manifest keys. That produces backslashes on Windows while the manifest uses canonical forward-slash paths, so a valid Windows checkout could reject the complete vendored source tree before SOL initialization.
+
+v0.1.1 fixes that bug by using POSIX manifest keys on every platform. It also:
+
+- pins the vendored snapshot to LF checkout in `.gitattributes`;
+- accepts only Git-style CRLF-to-LF transport normalization when validating canonical packaged hashes;
+- keeps every other file-content difference fail-closed;
+- scopes CuTe/Triton runtime dependencies to Linux so native-Windows installation does not try to install an unsupported/unvalidated custom-kernel toolchain;
+- runs provenance regression tests on `windows-latest` CI.
+
+This fixes the false provenance failure. It does **not** claim native-Windows CuTe execution support.
+
+## `comfy_aimdo` / allocator crashes
+
+An error such as:
+
+```text
+OSError: exception: access violation reading 0x0000000000000000
+...
+comfy_aimdo.malloc_graph ... malloc_graph_pop
+RuntimeError: aimdo memory compile error
+```
+
+is a separate execution path from Sol-Attn. In issue #4 the final v0.1.0 Sol-H3 telemetry showed:
+
+```text
+sol_backend: null
+sol_source_tree_verified: false
+sparse_calls: 0
+exact_blocks: 600
+```
+
+Therefore no SOL sparse kernel executed in that failing request. The same request had `exact_fusion=true`, so Exact Runtime was the only Sol-H3 custom kernel path that actually executed. The log does not establish that either Sol-H3 or AIMDO was the root cause.
+
+v0.1.1 removes that ambiguity on native Windows: SOL cannot execute CuTe and falls back dense, while Exact Runtime automatically delegates to native H3 before importing or executing its Triton affine kernel. If `comfy_aimdo` still crashes after upgrading to v0.1.1, capture the new log. A failure with `sparse_calls=0` and `compatibility_fallbacks` containing `exact:native_windows_unvalidated` is evidence that neither Sol-H3 custom kernel path executed, so the remaining crash should be investigated in the ComfyUI/AIMDO path separately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-sol-h3"
-version = "0.1.0"
+version = "0.1.1"
 description = "Native ComfyUI MiniMax-H3 exact runtime and composable Sana Sol-Attn integration"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}
-dependencies = ["torch", "triton>=3.6.0,<4; sys_platform == 'linux'", "nvidia-cutlass-dsl[cu13]>=4.5.0", "cuda-python", "apache-tvm-ffi>=0.1.11"]
+dependencies = [
+    "torch",
+    "triton>=3.6.0,<4; sys_platform == 'linux'",
+    "nvidia-cutlass-dsl[cu13]>=4.5.0; sys_platform == 'linux'",
+    "cuda-python; sys_platform == 'linux'",
+    "apache-tvm-ffi>=0.1.11; sys_platform == 'linux'",
+]
 
 [project.optional-dependencies]
 test = ["pytest>=8", "ruff"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
 triton>=3.6.0,<4; sys_platform == "linux"
-nvidia-cutlass-dsl[cu13]>=4.5.0
-cuda-python
-apache-tvm-ffi>=0.1.11
+nvidia-cutlass-dsl[cu13]>=4.5.0; sys_platform == "linux"
+cuda-python; sys_platform == "linux"
+apache-tvm-ffi>=0.1.11; sys_platform == "linux"

--- a/sol_h3/exact.py
+++ b/sol_h3/exact.py
@@ -1,3 +1,5 @@
+import sys
+
 import torch
 
 
@@ -50,6 +52,12 @@ def affine(h, shift, scale, segments, verified):
 
 
 def ineligible_reason(block, args):
+    # The packaged Exact path relies on a Triton kernel and is production-tested
+    # only on Linux/WSL. Native-Windows third-party Triton builds plus ComfyUI's
+    # AIMDO malloc graph are not a validated execution contract, so fail closed
+    # to the untouched native H3 block rather than executing an unowned runtime.
+    if sys.platform == "win32":
+        return "native_windows_unvalidated"
     from comfy.ldm.minimax.model import DiTBlock
     from torch.nn.modules import module as hooks
     if type(block) is not DiTBlock or getattr(block.forward, "__func__", None) is not DiTBlock.forward:
@@ -68,6 +76,8 @@ def ineligible_reason(block, args):
 
 def execute_block(block, args, verified):
     # Keep native RMSNorm, AdaLN, attention, MLP and addcmul_ gate operations.
+    if sys.platform == "win32":
+        raise RuntimeError("Exact fusion is not validated on native Windows; use native H3 execution")
     from comfy.ldm.minimax.model import DiTBlock, _mod_gate
     from torch.nn.modules import module as module_hooks
 

--- a/sol_h3/nodes.py
+++ b/sol_h3/nodes.py
@@ -9,7 +9,7 @@ class SolH3Exact:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
     CATEGORY = "model/optimizations/Sol-H3"
-    DESCRIPTION = "Fuse native H3 affine modulation with intermediate rounding preserved. CUDA required; GPU validation pending."
+    DESCRIPTION = "Fuse native H3 affine modulation with intermediate rounding preserved on validated Linux/WSL CUDA. Native Windows delegates to untouched native H3."
 
     def apply(self, model):
         from .runtime import install
@@ -28,7 +28,7 @@ class SolH3Experimental:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
     CATEGORY = "model/optimizations/Sol-H3/experimental"
-    DESCRIPTION = "Approximate Sol-Attn through the packaged Sana CuTe kernel on eligible SM120 H3/VDN calls; unsupported calls fall back locally."
+    DESCRIPTION = "Approximate Sol-Attn through the packaged Sana CuTe kernel on eligible SM120 H3/VDN calls. SOL kernel execution requires Linux/WSL2; unsupported calls fall back locally."
 
     def apply(self, model, exact_fusion=True, tau=1.0, dense_evaluations=1, dense_layers=2):
         from .runtime import install

--- a/sol_h3/provenance.py
+++ b/sol_h3/provenance.py
@@ -8,17 +8,44 @@ REVISION = '2936c47637380842aaa4a4488fac5006cc542b70'
 CONTRACT = 'sana-sol-engine-sol-attn-64-rect-sm120-v2'
 
 
+def _manifest_name(path, source):
+    """Return a platform-independent manifest key for a source-tree path."""
+    return path.relative_to(source).as_posix()
+
+
+def _matches_packaged_hash(path, expected):
+    """Match exact bytes, or the same text after Git-style CRLF normalization.
+
+    The manifest records the canonical LF bytes committed by this project. Git
+    for Windows can materialize tracked text as CRLF depending on the user's
+    checkout configuration. Treat only CRLF -> LF as transport normalization;
+    every other byte difference remains a hard provenance failure.
+    """
+    data = path.read_bytes()
+    if hashlib.sha256(data).hexdigest() == expected:
+        return True
+    if b'\r\n' not in data:
+        return False
+    return hashlib.sha256(data.replace(b'\r\n', b'\n')).hexdigest() == expected
+
+
 def verify_source():
     root = Path(__file__).resolve().parent
-    manifest = json.loads((root / 'sol_manifest.json').read_text())
+    manifest = json.loads((root / 'sol_manifest.json').read_text(encoding='utf-8'))
     if manifest['revision'] != REVISION or manifest['source'] != SOURCE:
         raise RuntimeError('Packaged Sana source identity mismatch')
     source = root / '_vendor' / 'sol_attn'
-    actual = {str(p.relative_to(source)) for p in source.rglob('*')
+    actual = {_manifest_name(p, source) for p in source.rglob('*')
               if p.is_file() and '__pycache__' not in p.parts and p.suffix != '.pyc'}
-    if actual != set(manifest['files']):
-        raise RuntimeError('Packaged Sana source file set mismatch')
+    expected = set(manifest['files'])
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        raise RuntimeError(
+            'Packaged Sana source file set mismatch: '
+            f'missing={missing or []}, unexpected={unexpected or []}'
+        )
     for name, hashes in manifest['files'].items():
-        if hashlib.sha256((source / name).read_bytes()).hexdigest() != hashes['packaged_sha256']:
+        if not _matches_packaged_hash(source / name, hashes['packaged_sha256']):
             raise RuntimeError(f'Packaged Sana source hash mismatch: {name}')
     return manifest

--- a/sol_h3/sparse.py
+++ b/sol_h3/sparse.py
@@ -1,5 +1,6 @@
 """Native attention bridge to the packaged Sana Sol-H3 implementation."""
 import math
+import sys
 import time
 
 import torch
@@ -49,6 +50,11 @@ def load_kernel(device):
         from ._vendor.sol_attn import get_sol_attn_backend, sol_attn
         backend = get_sol_attn_backend(device)
         if backend != "cute_sm120":
+            if sys.platform == "win32":
+                raise RuntimeError(
+                    "native Windows cannot execute the required NVIDIA CUTLASS CuTe DSL backend; "
+                    "SM120 SOL attention currently requires Linux/WSL2"
+                )
             raise RuntimeError(
                 f"Sana selected {backend}; SM120 requires CuTe (cutlass.cute and cuda.bindings.driver)"
             )

--- a/tests/test_native_execution.py
+++ b/tests/test_native_execution.py
@@ -123,3 +123,10 @@ def test_global_forward_hooks_rejected(native, kind):
 def test_exact_cuda_capability_error_is_explicit():
     with pytest.raises(RuntimeError, match="requires CUDA"):
         exact.affine(torch.ones(1, 2), torch.zeros(1, 2), torch.zeros(1, 2), [(0, 1, 0)], set())
+
+
+def test_native_windows_exact_fails_closed(monkeypatch):
+    monkeypatch.setattr(exact.sys, "platform", "win32")
+    assert exact.ineligible_reason(object(), {}) == "native_windows_unvalidated"
+    with pytest.raises(RuntimeError, match="not validated on native Windows"):
+        exact.execute_block(object(), {}, set())

--- a/tests/test_sana_contract.py
+++ b/tests/test_sana_contract.py
@@ -3,7 +3,7 @@ import ast
 import hashlib
 import inspect
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import subprocess
 import sys
 
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 from sol_h3._vendor.sol_attn import interface
-from sol_h3.provenance import verify_source, REVISION
+from sol_h3.provenance import _manifest_name, verify_source, REVISION
 from tools.vendor_sol_attn import package_sources
 
 
@@ -43,6 +43,12 @@ def test_provenance_and_node_local_imports():
     assert 'BSD 3-Clause' in (root / 'sm100/LICENSE.flash-attention').read_text()
     assert 'Apache License' in (root.parent / 'LICENSE.Apache-2.0').read_text()
     assert 'NVIDIA' in (root / 'THIRD_PARTY_NOTICES.md').read_text()
+
+
+def test_manifest_names_are_platform_independent():
+    source = PureWindowsPath(r'C:\ComfyUI\custom_nodes\ComfyUI-Sol-H3\sol_h3\_vendor\sol_attn')
+    path = source / '_vendor' / 'flash_attn' / 'cute' / 'softmax.py'
+    assert _manifest_name(path, source) == '_vendor/flash_attn/cute/softmax.py'
 
 
 def test_public_api():
@@ -117,17 +123,38 @@ def test_import_without_global_checkout_or_pythonpath(tmp_path):
                    cwd=tmp_path, env=env, check=True)
 
 
-def test_tampered_source_cannot_claim_verified(tmp_path, monkeypatch):
+def _copy_provenance_tree(tmp_path, monkeypatch):
     import shutil
     from sol_h3 import provenance
     source = Path(provenance.__file__).parent
     shutil.copytree(source / '_vendor', tmp_path / '_vendor')
     shutil.copyfile(source / 'sol_manifest.json', tmp_path / 'sol_manifest.json')
     monkeypatch.setattr(provenance, '__file__', str(tmp_path / 'provenance.py'))
+    return provenance
+
+
+def test_git_crlf_checkout_preserves_provenance(tmp_path, monkeypatch):
+    provenance = _copy_provenance_tree(tmp_path, monkeypatch)
+    target = tmp_path / '_vendor/sol_attn/interface.py'
+    target.write_bytes(target.read_bytes().replace(b'\n', b'\r\n'))
+    assert provenance.verify_source()['revision'] == REVISION
+
+
+def test_tampered_source_cannot_claim_verified(tmp_path, monkeypatch):
+    provenance = _copy_provenance_tree(tmp_path, monkeypatch)
     target = tmp_path / '_vendor/sol_attn/interface.py'
     target.write_text(target.read_text() + '\n# corrupt\n')
     with pytest.raises(RuntimeError, match='hash mismatch: interface.py'):
         provenance.verify_source()
+
+
+def test_native_windows_missing_cute_reports_supported_path(monkeypatch):
+    from sol_h3 import sparse
+    monkeypatch.setattr(torch.cuda, 'get_device_capability', lambda device=None: (12, 0))
+    monkeypatch.setattr(interface, '_cute_runtime_available', lambda: False)
+    monkeypatch.setattr(sparse.sys, 'platform', 'win32')
+    with pytest.raises(RuntimeError, match=r'native Windows.*Linux/WSL2'):
+        sparse.load_kernel(torch.device('cuda'))
 
 
 def test_missing_cute_counts_no_sparse_and_caches_reason(monkeypatch):


### PR DESCRIPTION
## Problem

Issue #4 is not a workflow-linking error. The attached native-Windows RTX 5090 run exposed two independent paths:

1. **A real Sol-H3 provenance bug.** `verify_source()` rendered vendored relative paths with the host `Path` separator, while `sol_manifest.json` uses canonical `/` keys. On Windows, valid nested files therefore appeared absent/unexpected and every SOL-eligible call fell back with `Packaged Sana source file set mismatch`.
2. **A platform boundary, not an SM120 hardware mismatch.** RTX 5090 is SM120, but the packaged SOL path requires NVIDIA CUTLASS CuTe DSL `cute_sm120`. NVIDIA currently documents CuTe DSL Windows support as unsupported, so real SOL kernel execution requires Linux/WSL2.

The later `comfy_aimdo` access violation is not evidence of an SOL sparse-kernel crash: the issue telemetry has `sol_backend=null`, `sol_source_tree_verified=false`, and `sparse_calls=0`. However, `exact_fusion=true` did execute `exact_blocks=600`, so v0.1.0 still had one Sol-H3 custom-kernel path active inside the native-Windows AIMDO lifecycle.

## Fix

- canonicalize vendored manifest names with `Path.relative_to(...).as_posix()`;
- keep the vendored snapshot LF-stable with `.gitattributes`;
- accept only exact packaged bytes or Git-style CRLF -> LF transport normalization; arbitrary file changes still fail provenance;
- report missing native-Windows CuTe as an explicit Linux/WSL2 requirement and retain request-local dense fallback;
- fail Exact Runtime closed on native Windows before importing/executing its Triton affine kernel, delegating to the untouched native H3 block with `exact:native_windows_unvalidated` telemetry;
- scope Triton/CuTe/CUDA-Python/TVM-FFI runtime dependencies to Linux because no Sol-H3 custom kernel is executed natively on Windows;
- add Windows CI covering path semantics, CRLF transport, tamper rejection, native-Windows CuTe diagnostics, and Exact fallback;
- document the platform boundary and AIMDO isolation procedure;
- bump the patch release to `v0.1.1`.

## Invariants / non-claims

- Linux/WSL SM120 SOL and Exact execution are unchanged.
- Rectangular Q/KV, VDN API-v3, Flow mixed-grid, Spectrum history, Untwist, and zero-copy BTHD contracts are unchanged.
- This does **not** claim native-Windows SOL acceleration.
- This does **not** claim that Sol-H3 caused the issue's AIMDO access violation. After this patch, native Windows executes neither Sol-H3 custom-kernel path; a remaining AIMDO failure is therefore separable from SOL/Exact kernel execution.

## Validation

Development was performed on `mirror/issue4-5090-windows-20260909` and consolidated here to exactly one implementation commit against current `main`.

Final mirror CI `34364222311` passed all three lanes:

- `test`: complete unit/contract suite, Ruff, pip check;
- `windows-provenance`: Windows path + CRLF + tamper + CuTe boundary + Exact fail-closed tests;
- `native-interop`: pinned v0.1.0 ComfyUI/companion integration suite.

I also checkpoint-tested the same implementation against current ComfyUI master `54e03f5367ebd8d96380e4cf02fa3084f7a7eca5` (after upstream `Comfy Aimdo 0.5.3 + Memory compiler fixes (#16180)`). Validation run `34364352165` passed `test`, `windows-provenance`, and `native-interop`; that current-master CI-only pin is intentionally not part of this release diff.

Topology:

```text
base    447b81e3c7d79b2ba1417f776e3fd5ca3d137cf4
head    8670c8fb007ae15dc8159a50d02c4cca86333bfe
commits 1
behind  0
```

Addresses #4.