### PR TITLE
Default SOL to the first denoiser evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.1.2 — 2026-09-09
+
+Changes the default SOL trajectory policy from one full dense denoiser evaluation to SOL from the first real denoiser evaluation.
+
+### Changed
+
+- `Sol-H3 SOL Attention (Experimental)` now defaults `dense_evaluations` to `0` instead of `1`.
+- Programmatic `Config(backend="sol")` uses the same `dense_evaluations=0` default.
+- `dense_layers=2` is unchanged; the first two H3 blocks remain dense inside each otherwise-SOL denoiser evaluation.
+- Existing saved workflows keep their serialized `dense_evaluations` value. Users can set `dense_evaluations=1` explicitly to retain the previous conservative trajectory warmup.
+- Spectrum backend-history safety is unchanged. Real numerical-route changes still invalidate incompatible history; the new default simply avoids creating the initial `dense -> sol` transition.
+
+### Controlled evidence
+
+Same-seed, same-reference, same-resolution, same-prompt, same-sampler, same-workflow hot runs with VDN disabled:
+
+| Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
+| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
+| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
+
+`metrics_00323` restores exact 25A/15F topology parity with the no-SOL control and reports backend history in `phase=sol` from the first call with `numerical_backend_transitions=0`. In this controlled hot pair, SOL is 42.28 s (11.3%) faster in H3 sampler wall time and 40.24 s (9.6%) faster end-to-end. These are deployment-specific measurements, not universal SOL percentages.
+
+The `dense_evaluations=0` output is visibly different from the `dense_evaluations=1` same-seed video, as expected for approximate attention affecting the trajectory from sigma 1.0, but manual inspection did not establish either as better or worse. This is not statistical perceptual-equivalence evidence.
+
+See `docs/DENSE_EVALUATIONS.md` for the scheduling rationale, timing interpretation, migration behavior, and the distinction between `dense_evaluations` and `dense_layers`.
+
 ## v0.1.1 — 2026-09-09
 
 Patch release for native-Windows installation/provenance behavior reported in issue #4.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native MiniMax-H3 exact-runtime optimization and composable Sana Sol-Attn integration for ComfyUI.
 
-**v0.1.1** packages the real Sol-Attn implementation from [`xmarre/Sana`, branch `sol-engine`](https://github.com/xmarre/Sana/tree/2936c47637380842aaa4a4488fac5006cc542b70/models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn), pinned at revision `2936c47637380842aaa4a4488fac5006cc542b70`. On supported SM120 Linux/WSL2 systems it executes Sana's CuTe `cute_sm120` backend; `comfy_kitchen.sol_attn` is not substituted for it.
+**v0.1.2** packages the real Sol-Attn implementation from [`xmarre/Sana`, branch `sol-engine`](https://github.com/xmarre/Sana/tree/2936c47637380842aaa4a4488fac5006cc542b70/models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn), pinned at revision `2936c47637380842aaa4a4488fac5006cc542b70`. On supported SM120 Linux/WSL2 systems it executes Sana's CuTe `cute_sm120` backend; `comfy_kitchen.sol_attn` is not substituted for it.
 
 The release has three parts:
 
@@ -12,13 +12,40 @@ The release has three parts:
 
 Unvalidated combinations are experimental telemetry rather than blanket errors. Hard failures are reserved for broken contracts, unsafe geometry/indexing, failed arithmetic verification or real execution failures.
 
-> **Native Windows:** RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support Windows. The real `cute_sm120` SOL kernel therefore requires Linux/WSL2. v0.1.1 fixes Windows provenance/install diagnostics, falls SOL back to inherited dense attention, and fails Exact Runtime closed to untouched native H3 before its Triton affine kernel can execute. It does not claim native-Windows SOL acceleration. See [Native Windows status](docs/WINDOWS.md).
+> **Native Windows:** RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support Windows. The real `cute_sm120` SOL kernel therefore requires Linux/WSL2. v0.1.1 fixed Windows provenance/install diagnostics, falls SOL back to inherited dense attention, and fails Exact Runtime closed to untouched native H3 before its Triton affine kernel can execute. It does not claim native-Windows SOL acceleration. See [Native Windows status](docs/WINDOWS.md).
+
+## v0.1.2 default: SOL from the first denoiser evaluation
+
+`Sol-H3 SOL Attention (Experimental)` now defaults to:
+
+```text
+dense_evaluations = 0
+dense_layers      = 2
+```
+
+The previous `dense_evaluations=1` default deliberately executed the first whole denoiser evaluation with inherited dense attention and then switched to SOL. With Spectrum, that `dense -> sol` numerical-backend transition invalidates the dense forecasting anchor, so the would-be first forecast becomes an additional actual transformer NFE.
+
+The default is now `0`: the first actual denoiser evaluation is already a SOL-side anchor, so Spectrum does not need an extra NFE solely to cross that backend boundary. Spectrum's backend-history invariant is unchanged; real numerical-route changes still invalidate incompatible forecasting history.
+
+`dense_layers=2` is unchanged. It keeps the first two H3 blocks dense inside each otherwise-SOL evaluation and does **not** add a full transformer NFE.
+
+Controlled no-VDN hot evidence with the same seed, references, resolution, prompt, sampler and workflow:
+
+| Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
+| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
+| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
+
+`metrics_00323` therefore has exact NFE/forecast topology parity with the no-SOL control while remaining 42.28 s (11.3%) faster in H3 sampler wall time and 40.24 s (9.6%) faster end-to-end in that controlled hot pair. This is one deployment-instance measurement, not a universal SOL percentage. The same-seed video changed visibly, as expected for approximate attention acting from sigma 1.0, but manual inspection did not establish either output as better or worse. That is not a statistical perceptual-equivalence result.
+
+Existing saved workflows keep their serialized `dense_evaluations` value. Set `dense_evaluations=1` explicitly to retain the previous conservative trajectory warmup. See [SOL trajectory warmup](docs/DENSE_EVALUATIONS.md) for the scheduling rationale, timing breakdown, telemetry caveat and quality boundary.
 
 ## v0.1.0 production status
 
-The full production stack has been exercised on an **NVIDIA RTX PRO 6000 Blackwell Workstation Edition (SM120)** with PyTorch `2.10.0+cu130`.
+The original full production stack was exercised on an **NVIDIA RTX PRO 6000 Blackwell Workstation Edition (SM120)** with PyTorch `2.10.0+cu130`.
 
-The final validated stack preserves the expected Spectrum schedule:
+The v0.1.0 validation used the older one-evaluation dense warmup and produced:
 
 ```text
 sampler_logical_calls       18
@@ -30,13 +57,15 @@ high:   4 actual / 2 forecast
 probe:  2 actual / 0 forecast
 ```
 
-The SOL-bypassed control executes `13 actual + 5 forecast`; the one additional SOL actual is the deliberate first low-stage `dense -> sol` numerical-backend transition and remains a safety anchor.
+The SOL-bypassed control executed `13 actual + 5 forecast`; that historical extra SOL actual was the first low-stage `dense -> sol` numerical-backend transition. v0.1.2 removes that transition from the default policy rather than weakening Spectrum's history gate.
 
-The real packaged kernel, VDN API-v3 rectangular route, Flow mixed-grid route, Spectrum receipts/history, Untwist preprocessing and zero-copy BTHD bridge all passed production execution. See [Validation](docs/VALIDATION.md) for the full evidence matrix.
+The real packaged kernel, VDN API-v3 rectangular route, Flow mixed-grid route, Spectrum receipts/history, Untwist preprocessing and zero-copy BTHD bridge all passed production execution. See [Validation](docs/VALIDATION.md) for the original evidence matrix and [SOL trajectory warmup](docs/DENSE_EVALUATIONS.md) for the v0.1.2 default change.
 
 ## Nodes and composition
 
 Apply MODEL patches and then apply **Sol-H3 SOL Attention (Experimental)** before sampling. `exact_fusion=true` also requests Exact Runtime. A later **Sol-H3 Exact Runtime** node merges with the same lifecycle rather than installing a second one.
+
+The SOL node defaults to `tau=1.0`, `dense_evaluations=0`, and `dense_layers=2`. `dense_evaluations` is an explicit trajectory-level dense warmup; `dense_layers` is a per-evaluation leading-layer dense policy. They are not interchangeable.
 
 On native Windows, the node can remain in the workflow but both custom-kernel paths fail closed: SOL delegates to inherited dense attention because CuTe is unavailable, and Exact Runtime records `exact:native_windows_unvalidated` then executes the untouched native H3 block. Linux/WSL2 behavior is unchanged.
 
@@ -44,7 +73,7 @@ Supported composition includes Exact -> SOL, SOL -> Exact and repeated identical
 
 SOL wraps existing block replacements. Every attention call either executes SOL or delegates to the inherited owner with an explicit route/fallback receipt. A valid run may legitimately contain zero sparse calls.
 
-Generic `optimized_attention_override` providers such as KJ Sage remain the dense owner for warmup/dense-required rows when usable. Loader-level `ImportError`/`OSError` failures are request-locally demoted to original Comfy attention with telemetry; arbitrary CUDA/runtime compute failures are not swallowed.
+Generic `optimized_attention_override` providers such as KJ Sage remain the dense owner for explicit dense-evaluation warmup, dense leading layers and other dense-required rows when usable. Loader-level `ImportError`/`OSError` failures are request-locally demoted to original Comfy attention with telemetry; arbitrary CUDA/runtime compute failures are not swallowed.
 
 ## Interoperability companions
 
@@ -96,7 +125,7 @@ Representative native production stages:
 | Native high | 1,056 | 4,972,800 | 4,972,800 | 0 |
 | Later native high | 1,248 | 5,967,360 | 5,967,360 | 0 |
 
-The historical v2 compatibility bridge expanded Q work by roughly **4.4–5.4x** in the affected stages. v3 removes that kernel-row expansion while leaving VDN's K/V domain semantics intact.
+The historical v2 compatibility bridge expanded Q work by roughly **4.4–5.4x** in the affected native stages. v3 removes that kernel-row expansion while leaving VDN's K/V domain semantics intact.
 
 Global/anchor calls remain VDN-native. Masked Flex remains VDN-native; its existing grouped fallback can use v3.
 
@@ -131,10 +160,10 @@ Production-only history issues found during validation were fixed narrowly:
 
 - audited Diff-Aid activation wrappers are transparent only when Diff-Aid publishes its runtime declaration;
 - Flow's marked layout wrapper and mixed-grid wrapper are recognized only when exact marker/closure/geometry invariants agree;
-- progressive high stages consume Flow's explicit continuation contract so the default one-evaluation dense warmup is not spuriously restarted;
+- progressive high stages consume Flow's explicit continuation contract so an explicitly requested one-evaluation trajectory warmup is not spuriously restarted;
 - unknown/malformed wrappers remain opaque and force an actual call rather than weakening the gate.
 
-Untwist preprocessing remains exactly once. Receipt/provider transitions still reset incompatible history.
+Untwist preprocessing remains exactly once. Receipt/provider transitions still reset incompatible history. With the v0.1.2 default `dense_evaluations=0`, the first backend-history phase is already `sol`, so no default trajectory-level `dense -> sol` reset is created.
 
 ## SOL kernel contract
 
@@ -199,18 +228,29 @@ Historical matched production A/B:
 
 This is Exact-only evidence, not a SOL speed claim.
 
-### SOL whole-workflow timing
+### Controlled SOL-first A/B
 
-A pre-zero-copy same-process hot SOL run with the final 14/4 Spectrum schedule measured:
+The v0.1.2 `dense_evaluations=0` run (`metrics_00323`) and the no-SOL control (`metrics_00322`) both executed `40 logical / 25 actual / 15 forecast` calls. That removes the old NFE-topology confound:
+
+```text
+SOL, dense_evaluations=0:  332.56 s sampler / 380.57 s end-to-end
+SOL disabled:              374.84 s sampler / 420.81 s end-to-end
+```
+
+In this controlled hot pair, SOL reduces H3 sampler wall by 42.28 s (11.3%) and end-to-end wall by 40.24 s (9.6%). Arithmetic-gate and general hot-run variance still exist, so this remains deployment-specific evidence rather than a universal percentage.
+
+### Historical SOL whole-workflow timing
+
+A pre-zero-copy same-process hot SOL run with the old 14/4 Spectrum schedule measured:
 
 ```text
 end-to-end prompt       274.87 s
 H3ContinuumSamplerV34   229.13 s
 ```
 
-That run was faster than the SOL-bypassed control (`287.51 s` end-to-end / `240.55 s` sampler) despite executing one extra actual transformer NFE, but this is **not** claimed as a clean SOL speed percentage because routing/content/cache state were not a controlled A/B.
+That run was faster than the SOL-bypassed control (`287.51 s` end-to-end / `240.55 s` sampler) despite executing one extra actual transformer NFE, but this is **not** a clean SOL speed percentage because routing/content/cache state and NFE topology differed.
 
-Subsequent zero-copy workflow runs varied materially (`287.29/239.10 s` and `298.59/247.63 s` end-to-end/sampler) while preserving the same 14/4 schedule. Arithmetic-gate/caching cost also varied. Therefore the release makes no large whole-workflow zero-copy claim; the isolated kernel/layout A/B above is the authoritative zero-copy result.
+Subsequent zero-copy workflow runs varied materially (`287.29/239.10 s` and `298.59/247.63 s` end-to-end/sampler) while preserving the old 14/4 schedule. Arithmetic-gate/caching cost also varied. Therefore the isolated kernel/layout A/B remains the authoritative zero-copy result.
 
 ## Installation
 
@@ -254,7 +294,7 @@ python -m ruff check .
 python -m pytest -q
 ```
 
-GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows provenance and AIMDO isolation guidance is in [WINDOWS](docs/WINDOWS.md).
+GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). The v0.1.2 trajectory-warmup decision and controlled hot evidence are documented in [DENSE_EVALUATIONS](docs/DENSE_EVALUATIONS.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows provenance and AIMDO isolation guidance is in [WINDOWS](docs/WINDOWS.md).
 
 Useful counters include:
 
@@ -281,11 +321,13 @@ numerical_backend_transitions
 compatibility_fallbacks
 ```
 
+The legacy `dense_warmup` telemetry value counts attention calls kept dense by either `dense_evaluations` or `dense_layers`; it is not a count of full dense denoiser evaluations. With the v0.1.2 defaults it can therefore remain nonzero even though `dense_evaluations=0` and backend history starts in `phase=sol`.
+
 A successful run with zero sparse calls is valid execution telemetry but is not evidence of SOL acceleration.
 
 ## Release notes
 
-See [CHANGELOG.md](CHANGELOG.md) for the v0.1.1 release summary and validation boundaries.
+See [CHANGELOG.md](CHANGELOG.md) for the v0.1.2 release summary and validation boundaries.
 
 `sol_h3/sol_manifest.json` records original upstream hashes and packaged hashes. `tools/rectangular_sm120.patch` records the functional rectangular changes after import adaptation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,68 @@
+# ComfyUI-Sol-H3 v0.1.2
+
+Patch release changing the default SOL trajectory policy so new workflows start SOL on the first real denoiser evaluation instead of burning a full dense evaluation before switching numerical backends.
+
+## Default change
+
+`Sol-H3 SOL Attention (Experimental)` now defaults to:
+
+```text
+dense_evaluations = 0
+dense_layers      = 2
+```
+
+The previous `dense_evaluations=1` default created an initial `dense -> sol` numerical-backend transition. Spectrum correctly invalidates forecasting history across that transition, so the first would-be forecast became an additional actual transformer NFE solely to establish a SOL-side anchor.
+
+v0.1.2 does not weaken Spectrum's history/receipt safety. It removes that unnecessary transition from the default policy. Existing saved workflows retain their serialized `dense_evaluations` value, and `dense_evaluations=1` remains available as an explicit conservative trajectory warmup.
+
+`dense_layers=2` is unchanged. It keeps the first two H3 blocks dense inside each otherwise-SOL denoiser evaluation and does not add a full transformer NFE.
+
+## Controlled hot evidence
+
+Same seed, references, resolution, prompt, sampler, sampling settings and workflow structure; VDN disabled in all three runs:
+
+| Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
+| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
+| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
+
+The new default therefore restores exact NFE/forecast topology parity with the no-SOL control:
+
+```text
+40 logical
+25 actual NFE
+15 Spectrum forecasts
+
+low:    15 actual / 9 forecast
+high:    8 actual / 6 forecast
+probe:   2 actual / 0 forecast
+```
+
+`metrics_00323` starts backend history directly in `phase=sol` and reports `numerical_backend_transitions=0`.
+
+Against the topology-matched no-SOL control, the tested SOL run is 42.28 s (11.3%) faster in H3 sampler wall time and 40.24 s (9.6%) faster end-to-end. This is a controlled measurement for this MiniMax-H3/RTX PRO 6000 deployment instance, not a universal Sol-Attn percentage.
+
+Against the previous `dense_evaluations=1` SOL run, sampler wall falls by 20.80 s (5.9%) and end-to-end wall by 20.37 s (5.1%). Arithmetic-gate/calibration time also varied between hot runs, so the defensible structural gain is the restored forecast replacing one full actual NFE; the entire wall-time delta should not be assigned to that NFE alone.
+
+## Quality boundary
+
+The same-seed `dense_evaluations=0` output is visibly different from the `dense_evaluations=1` output, which is expected when approximate SOL attention affects the trajectory from sigma 1.0. Manual inspection did not establish either video as better or worse.
+
+That supports making zero the operational default for the tested stack, but it is not statistical perceptual-equivalence evidence. Users who want the previous conservative policy can set `dense_evaluations=1` explicitly.
+
+## Documentation and tests
+
+- Added `docs/DENSE_EVALUATIONS.md` with the backend-history rationale, timing evidence, quality boundary, migration behavior and the `dense_evaluations`/`dense_layers` distinction.
+- Updated the README and changelog to distinguish historical v0.1.0/v0.1.1 warmup behavior from the v0.1.2 default.
+- Added regression coverage verifying that new SOL configs and the ComfyUI node default to `dense_evaluations=0`, while explicit one-evaluation warmup and Flow continuation handling remain supported.
+
+## Telemetry caveat
+
+The existing `dense_warmup` telemetry field counts attention calls kept dense by either `dense_evaluations` or `dense_layers`. It can therefore remain nonzero with `dense_evaluations=0`. Use the configured `dense_evaluations`, backend-history `phase`, `numerical_backend_transitions`, and actual/forecast topology to diagnose whole-evaluation warmup behavior.
+
+---
+
 # ComfyUI-Sol-H3 v0.1.1
 
 Patch release addressing the native-Windows failure reported in issue #4 without claiming unsupported native-Windows SOL kernel execution.

--- a/docs/DENSE_EVALUATIONS.md
+++ b/docs/DENSE_EVALUATIONS.md
@@ -1,0 +1,94 @@
+# SOL trajectory warmup (`dense_evaluations`)
+
+## Current default
+
+Starting with **v0.1.2**, `Sol-H3 SOL Attention (Experimental)` defaults to:
+
+```text
+dense_evaluations = 0
+dense_layers      = 2
+```
+
+`dense_evaluations=0` means SOL is the numerical attention backend from the first real denoiser evaluation. `dense_layers=2` is unchanged: the first two H3 blocks of each otherwise-SOL evaluation remain dense. That per-layer policy does **not** add a transformer NFE.
+
+Existing saved workflows keep their serialized `dense_evaluations` value. The default change affects newly created nodes and programmatic `Config(backend="sol")` users.
+
+## Why the default changed
+
+The v0.1.0/v0.1.1 default was `dense_evaluations=1`. With Spectrum enabled, that creates a real numerical-backend boundary:
+
+```text
+first actual evaluation: dense
+next numerical route:    SOL
+```
+
+Spectrum correctly treats `dense -> sol` as incompatible forecasting history. The would-be first forecast therefore becomes an additional actual transformer evaluation so that Spectrum can establish a SOL-side anchor. The extra NFE is a consequence of the configured transition; it is not an intrinsic requirement of Sol-Attn.
+
+The fix is **not** to weaken Spectrum's backend-history invariant. It is to avoid creating the unnecessary trajectory-level backend transition by default.
+
+With `dense_evaluations=0`, backend history starts directly in `phase=sol`, so the first actual evaluation is already a valid SOL anchor and the normal Spectrum forecast topology is retained.
+
+## Controlled MiniMax-H3 evidence
+
+The default change was evaluated in a same-seed, same-reference, same-resolution, same-prompt, same-sampler, same-workflow hot comparison with VDN disabled. Only the named component/policy changed.
+
+| Run | SOL | `dense_evaluations` | Logical | Actual NFE | Forecasts | H3 sampler | End-to-end |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
+| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
+| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
+
+`metrics_00323` therefore restores exact NFE/forecast topology parity with the no-SOL control:
+
+```text
+40 logical
+25 actual NFE
+15 Spectrum forecasts
+
+low:    15 actual / 9 forecast
+high:    8 actual / 6 forecast
+probe:   2 actual / 0 forecast
+```
+
+The run also reports `phase=sol` from the first backend-history diagnostic and `numerical_backend_transitions=0`.
+
+Relative to the otherwise-matched `dense_evaluations=1` SOL run (`metrics_00321`), the H3 sampler decreased by 20.80 s (5.9%) and end-to-end wall time by 20.37 s (5.1%). The first progressive chunk fell from 149.13 s to 130.61 s. Not all of that wall-time delta should be assigned to the removed NFE because arithmetic-gate/calibration time also varied materially between hot runs; the topology change itself is the defensible structural gain.
+
+The topology-matched SOL-vs-no-SOL comparison is cleaner:
+
+```text
+metrics_00323 SOL, 25A/15F:     332.56 s sampler / 380.57 s end-to-end
+metrics_00322 no SOL, 25A/15F:  374.84 s sampler / 420.81 s end-to-end
+```
+
+That is a 42.28 s (11.3%) sampler reduction and a 40.24 s (9.6%) end-to-end reduction in this controlled hot pair. It remains one deployment-instance measurement, not a universal SOL percentage.
+
+## Quality boundary
+
+The same-seed `dense_evaluations=0` video was visibly different from the `dense_evaluations=1` output, as expected when approximate SOL attention is allowed to affect the trajectory from sigma 1.0. Manual inspection did **not** establish either output as better or worse.
+
+That is evidence against an obvious regression in this tested case, but it is not a statistical perceptual-equivalence result. Users who prefer the older conservative trajectory warmup can set:
+
+```text
+dense_evaluations = 1
+```
+
+and retain the previous behavior, including the Spectrum history boundary and possible extra actual NFE.
+
+## `dense_layers` is separate
+
+`dense_evaluations` and `dense_layers` control different things:
+
+- `dense_evaluations`: whole denoiser evaluations that stay on the inherited dense attention backend before SOL is allowed.
+- `dense_layers`: leading H3 blocks that remain dense inside every otherwise-SOL denoiser evaluation.
+
+v0.1.2 changes only the first default. `dense_layers=2` remains unchanged.
+
+The legacy `dense_warmup` telemetry field currently counts dense attention calls caused by either policy, so it can remain nonzero with `dense_evaluations=0`. For trajectory-history diagnosis, use the configured `dense_evaluations`, backend-history `phase`, `numerical_backend_transitions`, and the actual/forecast topology rather than interpreting `dense_warmup` as a count of full dense denoiser evaluations.
+
+## Compatibility and safety
+
+- Spectrum's numerical-backend history/receipt checks remain unchanged and fail closed across real route changes.
+- `dense_evaluations > 0` remains supported as an explicit user policy.
+- Flow progressive high-stage continuation handling for an explicit one-evaluation warmup remains supported; it prevents a trajectory-start warmup from being spuriously restarted at a known continuation boundary.
+- Unknown/malformed routing still executes actual/inherited attention rather than forecasting across an unproven numerical route.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-sol-h3"
-version = "0.1.1"
+version = "0.1.2"
 description = "Native ComfyUI MiniMax-H3 exact runtime and composable Sana Sol-Attn integration"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}

--- a/sol_h3/contracts.py
+++ b/sol_h3/contracts.py
@@ -13,7 +13,7 @@ class Config:
     exact: bool = True
     backend: str = "inherit"
     tau: float = 1.0
-    dense_evaluations: int = 1
+    dense_evaluations: int = 0
     dense_layers: int = 2
 
     def __post_init__(self):

--- a/sol_h3/nodes.py
+++ b/sol_h3/nodes.py
@@ -22,15 +22,15 @@ class SolH3Experimental:
         return {"required": {"model": ("MODEL",),
                 "exact_fusion": ("BOOLEAN", {"default": True}),
                 "tau": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 3.0, "step": 0.1}),
-                "dense_evaluations": ("INT", {"default": 1, "min": 0, "max": 100}),
+                "dense_evaluations": ("INT", {"default": 0, "min": 0, "max": 100}),
                 "dense_layers": ("INT", {"default": 2, "min": 0, "max": 100})}}
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
     CATEGORY = "model/optimizations/Sol-H3/experimental"
-    DESCRIPTION = "Approximate Sol-Attn through the packaged Sana CuTe kernel on eligible SM120 H3/VDN calls. SOL kernel execution requires Linux/WSL2; unsupported calls fall back locally."
+    DESCRIPTION = "Approximate Sol-Attn through the packaged Sana CuTe kernel on eligible SM120 H3/VDN calls. The default starts SOL on the first denoiser evaluation; set dense_evaluations > 0 only for an explicit trajectory-level dense warmup. SOL kernel execution requires Linux/WSL2; unsupported calls fall back locally."
 
-    def apply(self, model, exact_fusion=True, tau=1.0, dense_evaluations=1, dense_layers=2):
+    def apply(self, model, exact_fusion=True, tau=1.0, dense_evaluations=0, dense_layers=2):
         from .runtime import install
         return (install(model, Config(exact_fusion, "sol", tau, dense_evaluations, dense_layers)),)
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,38 @@
+from inspect import signature
+
+from sol_h3.contracts import Config
+from sol_h3.interop import dense_evaluation_warmup
+from sol_h3.nodes import SolH3Experimental
+
+
+def test_sol_default_starts_on_first_denoiser_evaluation():
+    config = Config(backend="sol")
+    assert config.dense_evaluations == 0
+    assert config.dense_layers == 2
+    assert dense_evaluation_warmup(config, 0, {}) is False
+
+    inputs = SolH3Experimental.INPUT_TYPES()["required"]
+    assert inputs["dense_evaluations"][1]["default"] == 0
+    assert inputs["dense_layers"][1]["default"] == 2
+    assert signature(SolH3Experimental.apply).parameters["dense_evaluations"].default == 0
+
+
+def test_dense_evaluation_warmup_remains_an_explicit_opt_in():
+    config = Config(backend="sol", dense_evaluations=1)
+    assert dense_evaluation_warmup(config, 0, {}) is True
+    assert dense_evaluation_warmup(config, 1, {}) is False
+
+
+def test_progressive_high_continuation_does_not_restart_single_eval_opt_in():
+    config = Config(backend="sol", dense_evaluations=1)
+    options = {
+        "h3_flow_stage": "high",
+        "h3_refinement": {
+            "api": 1,
+            "active": True,
+            "source": "h3_flow_progressive_handoff",
+            "min_actual_prefix_steps": 1,
+            "sigma_reference": 1.0,
+        },
+    }
+    assert dense_evaluation_warmup(config, 0, options) is False


### PR DESCRIPTION
## Summary

Change the Sol-H3 SOL Attention default from `dense_evaluations=1` to `0` and prepare v0.1.2.

The old default intentionally ran the first whole denoiser evaluation on inherited dense attention, then switched to SOL. With Spectrum, that real `dense -> sol` numerical-backend transition invalidates the dense forecasting anchor, so the first would-be forecast becomes an extra actual transformer NFE. The new default starts in `phase=sol` on the first actual evaluation instead of weakening Spectrum's backend-history invariant.

`dense_layers=2` remains unchanged. Existing saved workflows retain their serialized `dense_evaluations` value, and `dense_evaluations=1` remains an explicit opt-in conservative trajectory warmup.

## Controlled production evidence

Same seed, references, resolution, prompt, sampler, sampling settings and workflow structure; VDN disabled:

| Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
|---|---|---:|---:|---:|---:|---:|---:|
| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |

`metrics_00323` restores exact topology parity with the no-SOL control: `40 logical / 25 actual / 15 forecast`, with low `15A/9F`, high `8A/6F`, probes `2A/0F`. Backend history starts directly in `phase=sol` and reports `numerical_backend_transitions=0`.

Against the topology-matched no-SOL control, this hot pair measures `-42.28 s` (`-11.3%`) H3 sampler and `-40.24 s` (`-9.6%`) end-to-end. This is deployment-specific evidence, not a universal SOL percentage.

Against the old `dense_evaluations=1` SOL run, sampler wall falls `20.80 s` (`5.9%`) and end-to-end `20.37 s` (`5.1%`). Arithmetic-gate/calibration time also varied, so the defensible structural gain is one forecast replacing one full actual NFE; the full wall delta is not attributed solely to the removed NFE.

## Quality boundary

The same-seed `dense_evaluations=0` output is visibly different from the `dense_evaluations=1` output, as expected when approximate SOL attention affects the trajectory from sigma 1.0. Manual inspection did not establish either as better or worse. This is not statistical perceptual-equivalence evidence.

## Changes

- default `Config.dense_evaluations`: `1 -> 0`
- ComfyUI node schema/function default: `1 -> 0`
- keep `dense_layers=2`
- add regression tests for the SOL-first default, explicit warmup opt-in and Flow continuation behavior
- add `docs/DENSE_EVALUATIONS.md`
- update README, changelog and v0.1.2 release notes
- bump package version to `0.1.2`

## Safety / compatibility

- Spectrum history/receipt semantics are unchanged.
- Real backend transitions still reset incompatible history.
- `dense_evaluations > 0` remains supported.
- Existing serialized workflows do not silently change their saved value.
- Native-Windows fail-closed behavior from v0.1.1 is unchanged.

Checkpoint: `checkpoint/sol-first-default-documented-20260909` at `38ec606c9ad8c10008b56e6eff53d910fd3dc261`.