### PR TITLE
Restore conservative SOL warmup default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v0.1.3 — 2026-09-09
+
+Restores the conservative one-evaluation dense SOL warmup after a controlled same-seed video comparison exposed a startup trajectory discontinuity when SOL approximation was enabled from the first sigma-1.0 evaluation.
+
+### Changed
+
+- `Sol-H3 SOL Attention (Experimental)` defaults `dense_evaluations` back to `1`.
+- Programmatic `Config(backend="sol")` uses the same `dense_evaluations=1` default.
+- `dense_evaluations=0` remains supported as an explicit maximum-speed mode. With Spectrum it can avoid one actual transformer NFE by eliminating the initial `dense -> sol` history boundary.
+- `dense_layers=2` remains unchanged.
+- Existing saved workflows keep their serialized value; workflows created or saved under v0.1.2 can therefore remain at `0` until changed explicitly.
+
+### Quality evidence
+
+A subsequent controlled same-seed comparison established a concrete failure mode for the SOL-first policy. With `dense_evaluations=0`, the opening motion showed an abrupt pose/orientation change with heavy early smearing before settling into the opposite heading. With `dense_evaluations=1`, the corresponding opening motion remained a continuous turn.
+
+This is evidence that SOL from the first denoiser evaluation **can** destabilize the initial trajectory. It does not establish the frequency of the artifact across seeds, prompts, references, resolutions or model variants. The default is restored to `1` on quality-risk grounds.
+
+### Spectrum / performance boundary
+
+The v0.1.2 scheduling analysis remains valid: `dense_evaluations=1` creates a real `dense -> sol` numerical-backend transition, and Spectrum correctly invalidates incompatible forecasting history across it. The first would-be forecast can therefore become an additional actual transformer NFE to establish a SOL-side anchor.
+
+The previous controlled hot evidence remains the measured speed trade-off:
+
+| Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
+| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
+| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
+
+Do not weaken Spectrum's history/receipt invariant to recover that NFE while retaining a dense-to-SOL transition. The extra actual evaluation is the correct consequence of crossing numerical attention backends mid-trajectory.
+
+See `docs/DENSE_EVALUATIONS.md` for the current default, migration behavior, speed/quality trade-off and telemetry guidance.
+
 ## v0.1.2 — 2026-09-09
 
 Changes the default SOL trajectory policy from one full dense denoiser evaluation to SOL from the first real denoiser evaluation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native MiniMax-H3 exact-runtime optimization and composable Sana Sol-Attn integration for ComfyUI.
 
-**v0.1.2** packages the real Sol-Attn implementation from [`xmarre/Sana`, branch `sol-engine`](https://github.com/xmarre/Sana/tree/2936c47637380842aaa4a4488fac5006cc542b70/models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn), pinned at revision `2936c47637380842aaa4a4488fac5006cc542b70`. On supported SM120 Linux/WSL2 systems it executes Sana's CuTe `cute_sm120` backend; `comfy_kitchen.sol_attn` is not substituted for it.
+**v0.1.3** packages the real Sol-Attn implementation from [`xmarre/Sana`, branch `sol-engine`](https://github.com/xmarre/Sana/tree/2936c47637380842aaa4a4488fac5006cc542b70/models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn), pinned at revision `2936c47637380842aaa4a4488fac5006cc542b70`. On supported SM120 Linux/WSL2 systems it executes Sana's CuTe `cute_sm120` backend; `comfy_kitchen.sol_attn` is not substituted for it.
 
 The release has three parts:
 
@@ -14,22 +14,24 @@ Unvalidated combinations are experimental telemetry rather than blanket errors. 
 
 > **Native Windows:** RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support Windows. The real `cute_sm120` SOL kernel therefore requires Linux/WSL2. v0.1.1 fixed Windows provenance/install diagnostics, falls SOL back to inherited dense attention, and fails Exact Runtime closed to untouched native H3 before its Triton affine kernel can execute. It does not claim native-Windows SOL acceleration. See [Native Windows status](docs/WINDOWS.md).
 
-## v0.1.2 default: SOL from the first denoiser evaluation
+## v0.1.3 default: one dense trajectory evaluation
 
 `Sol-H3 SOL Attention (Experimental)` now defaults to:
 
 ```text
-dense_evaluations = 0
+dense_evaluations = 1
 dense_layers      = 2
 ```
 
-The previous `dense_evaluations=1` default deliberately executed the first whole denoiser evaluation with inherited dense attention and then switched to SOL. With Spectrum, that `dense -> sol` numerical-backend transition invalidates the dense forecasting anchor, so the would-be first forecast becomes an additional actual transformer NFE.
+`dense_evaluations=1` keeps the first complete denoiser evaluation on inherited dense attention, then enables SOL. `dense_layers=2` remains separate: the first two H3 blocks of each otherwise-SOL evaluation stay dense and do **not** add a transformer NFE.
 
-The default is now `0`: the first actual denoiser evaluation is already a SOL-side anchor, so Spectrum does not need an extra NFE solely to cross that backend boundary. Spectrum's backend-history invariant is unchanged; real numerical-route changes still invalidate incompatible forecasting history.
+v0.1.2 temporarily changed the default to `dense_evaluations=0` because the initial `dense -> sol` numerical-backend transition invalidates Spectrum's dense forecasting anchor and can turn the first would-be forecast into an additional actual transformer NFE. Starting directly in `phase=sol` avoids that extra NFE.
 
-`dense_layers=2` is unchanged. It keeps the first two H3 blocks dense inside each otherwise-SOL evaluation and does **not** add a full transformer NFE.
+That scheduling analysis remains correct, but a subsequent controlled same-seed video comparison exposed a concrete quality risk when SOL approximation acts from the first sigma-1.0 evaluation. With `dense_evaluations=0`, the opening motion showed an abrupt pose/orientation change with heavy early smearing before settling into the opposite heading. With `dense_evaluations=1`, the corresponding opening motion remained a continuous turn.
 
-Controlled no-VDN hot evidence with the same seed, references, resolution, prompt, sampler and workflow:
+The pair establishes that SOL-first execution **can** destabilize the initial trajectory. It does not establish how frequently this occurs across seeds, prompts, references, resolutions or model variants. v0.1.3 therefore restores `1` as the quality-conservative default while keeping `0` available as an explicit maximum-speed mode.
+
+Previous controlled no-VDN hot evidence remains the measured speed trade-off:
 
 | Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
 |---|---|---:|---:|---:|---:|---:|---:|
@@ -37,15 +39,15 @@ Controlled no-VDN hot evidence with the same seed, references, resolution, promp
 | `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
 | `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
 
-`metrics_00323` therefore has exact NFE/forecast topology parity with the no-SOL control while remaining 42.28 s (11.3%) faster in H3 sampler wall time and 40.24 s (9.6%) faster end-to-end in that controlled hot pair. This is one deployment-instance measurement, not a universal SOL percentage. The same-seed video changed visibly, as expected for approximate attention acting from sigma 1.0, but manual inspection did not establish either output as better or worse. That is not a statistical perceptual-equivalence result.
+`dense_evaluations=0` restored exact NFE/forecast topology parity with the no-SOL control in that test and removed one actual NFE relative to `dense_evaluations=1`. The timing remains deployment-specific and is not a quality-equivalence result. Do not weaken Spectrum's history/receipt safety to recover that NFE while retaining a dense-to-SOL transition.
 
-Existing saved workflows keep their serialized `dense_evaluations` value. Set `dense_evaluations=1` explicitly to retain the previous conservative trajectory warmup. See [SOL trajectory warmup](docs/DENSE_EVALUATIONS.md) for the scheduling rationale, timing breakdown, telemetry caveat and quality boundary.
+Existing saved workflows keep their serialized `dense_evaluations` value. Workflows created or saved under v0.1.2 can therefore remain at `0` after upgrading until changed explicitly. See [SOL trajectory warmup](docs/DENSE_EVALUATIONS.md) for the speed/quality trade-off, migration behavior and telemetry guidance.
 
 ## v0.1.0 production status
 
 The original full production stack was exercised on an **NVIDIA RTX PRO 6000 Blackwell Workstation Edition (SM120)** with PyTorch `2.10.0+cu130`.
 
-The v0.1.0 validation used the older one-evaluation dense warmup and produced:
+The v0.1.0 validation used the one-evaluation dense warmup and produced:
 
 ```text
 sampler_logical_calls       18
@@ -57,15 +59,15 @@ high:   4 actual / 2 forecast
 probe:  2 actual / 0 forecast
 ```
 
-The SOL-bypassed control executed `13 actual + 5 forecast`; that historical extra SOL actual was the first low-stage `dense -> sol` numerical-backend transition. v0.1.2 removes that transition from the default policy rather than weakening Spectrum's history gate.
+The SOL-bypassed control executed `13 actual + 5 forecast`; the additional SOL actual was the first low-stage `dense -> sol` numerical-backend transition. v0.1.2 removed that transition from the default for speed; v0.1.3 restores it as the default after the startup-quality regression described above. `dense_evaluations=0` remains available when the speed trade-off is explicitly desired.
 
-The real packaged kernel, VDN API-v3 rectangular route, Flow mixed-grid route, Spectrum receipts/history, Untwist preprocessing and zero-copy BTHD bridge all passed production execution. See [Validation](docs/VALIDATION.md) for the original evidence matrix and [SOL trajectory warmup](docs/DENSE_EVALUATIONS.md) for the v0.1.2 default change.
+The real packaged kernel, VDN API-v3 rectangular route, Flow mixed-grid route, Spectrum receipts/history, Untwist preprocessing and zero-copy BTHD bridge all passed production execution. See [Validation](docs/VALIDATION.md) for the original evidence matrix and [SOL trajectory warmup](docs/DENSE_EVALUATIONS.md) for the current default policy.
 
 ## Nodes and composition
 
 Apply MODEL patches and then apply **Sol-H3 SOL Attention (Experimental)** before sampling. `exact_fusion=true` also requests Exact Runtime. A later **Sol-H3 Exact Runtime** node merges with the same lifecycle rather than installing a second one.
 
-The SOL node defaults to `tau=1.0`, `dense_evaluations=0`, and `dense_layers=2`. `dense_evaluations` is an explicit trajectory-level dense warmup; `dense_layers` is a per-evaluation leading-layer dense policy. They are not interchangeable.
+The SOL node defaults to `tau=1.0`, `dense_evaluations=1`, and `dense_layers=2`. `dense_evaluations` is a trajectory-level dense warmup; `dense_layers` is a per-evaluation leading-layer dense policy. They are not interchangeable. Set `dense_evaluations=0` only when explicitly choosing the faster SOL-first trajectory and accepting the documented startup-continuity risk.
 
 On native Windows, the node can remain in the workflow but both custom-kernel paths fail closed: SOL delegates to inherited dense attention because CuTe is unavailable, and Exact Runtime records `exact:native_windows_unvalidated` then executes the untouched native H3 block. Linux/WSL2 behavior is unchanged.
 
@@ -73,7 +75,7 @@ Supported composition includes Exact -> SOL, SOL -> Exact and repeated identical
 
 SOL wraps existing block replacements. Every attention call either executes SOL or delegates to the inherited owner with an explicit route/fallback receipt. A valid run may legitimately contain zero sparse calls.
 
-Generic `optimized_attention_override` providers such as KJ Sage remain the dense owner for explicit dense-evaluation warmup, dense leading layers and other dense-required rows when usable. Loader-level `ImportError`/`OSError` failures are request-locally demoted to original Comfy attention with telemetry; arbitrary CUDA/runtime compute failures are not swallowed.
+Generic `optimized_attention_override` providers such as KJ Sage remain the dense owner for dense-evaluation warmup, dense leading layers and other dense-required rows when usable. Loader-level `ImportError`/`OSError` failures are request-locally demoted to original Comfy attention with telemetry; arbitrary CUDA/runtime compute failures are not swallowed.
 
 ## Interoperability companions
 
@@ -160,10 +162,10 @@ Production-only history issues found during validation were fixed narrowly:
 
 - audited Diff-Aid activation wrappers are transparent only when Diff-Aid publishes its runtime declaration;
 - Flow's marked layout wrapper and mixed-grid wrapper are recognized only when exact marker/closure/geometry invariants agree;
-- progressive high stages consume Flow's explicit continuation contract so an explicitly requested one-evaluation trajectory warmup is not spuriously restarted;
+- progressive high stages consume Flow's explicit continuation contract so the one-evaluation trajectory warmup is not spuriously restarted;
 - unknown/malformed wrappers remain opaque and force an actual call rather than weakening the gate.
 
-Untwist preprocessing remains exactly once. Receipt/provider transitions still reset incompatible history. With the v0.1.2 default `dense_evaluations=0`, the first backend-history phase is already `sol`, so no default trajectory-level `dense -> sol` reset is created.
+Untwist preprocessing remains exactly once. Receipt/provider transitions still reset incompatible history. With the v0.1.3 default `dense_evaluations=1`, backend history begins dense and the later `dense -> sol` route change is intentionally treated as a real history boundary. With the explicit `dense_evaluations=0` speed mode, history starts directly in `phase=sol` and that initial transition is absent.
 
 ## SOL kernel contract
 
@@ -228,7 +230,7 @@ Historical matched production A/B:
 
 This is Exact-only evidence, not a SOL speed claim.
 
-### Controlled SOL-first A/B
+### Historical v0.1.2 SOL-first A/B
 
 The v0.1.2 `dense_evaluations=0` run (`metrics_00323`) and the no-SOL control (`metrics_00322`) both executed `40 logical / 25 actual / 15 forecast` calls. That removes the old NFE-topology confound:
 
@@ -237,7 +239,7 @@ SOL, dense_evaluations=0:  332.56 s sampler / 380.57 s end-to-end
 SOL disabled:              374.84 s sampler / 420.81 s end-to-end
 ```
 
-In this controlled hot pair, SOL reduces H3 sampler wall by 42.28 s (11.3%) and end-to-end wall by 40.24 s (9.6%). Arithmetic-gate and general hot-run variance still exist, so this remains deployment-specific evidence rather than a universal percentage.
+In this controlled hot pair, SOL reduced H3 sampler wall by 42.28 s (11.3%) and end-to-end wall by 40.24 s (9.6%). Arithmetic-gate and general hot-run variance still exist, so this remains deployment-specific evidence rather than a universal percentage. It is also **not** evidence that `dense_evaluations=0` is quality-equivalent: the later controlled startup comparison is why v0.1.3 restores the conservative default.
 
 ### Historical SOL whole-workflow timing
 
@@ -294,7 +296,7 @@ python -m ruff check .
 python -m pytest -q
 ```
 
-GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). The v0.1.2 trajectory-warmup decision and controlled hot evidence are documented in [DENSE_EVALUATIONS](docs/DENSE_EVALUATIONS.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows provenance and AIMDO isolation guidance is in [WINDOWS](docs/WINDOWS.md).
+GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). The v0.1.3 trajectory-warmup decision, historical timing evidence and startup-quality boundary are documented in [DENSE_EVALUATIONS](docs/DENSE_EVALUATIONS.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows provenance and AIMDO isolation guidance is in [WINDOWS](docs/WINDOWS.md).
 
 Useful counters include:
 
@@ -321,13 +323,13 @@ numerical_backend_transitions
 compatibility_fallbacks
 ```
 
-The legacy `dense_warmup` telemetry value counts attention calls kept dense by either `dense_evaluations` or `dense_layers`; it is not a count of full dense denoiser evaluations. With the v0.1.2 defaults it can therefore remain nonzero even though `dense_evaluations=0` and backend history starts in `phase=sol`.
+The legacy `dense_warmup` telemetry value counts attention calls kept dense by either `dense_evaluations` or `dense_layers`; it is not a count of full dense denoiser evaluations. Diagnose trajectory warmup with the configured `dense_evaluations`, backend-history `phase`, `numerical_backend_transitions`, and actual/forecast topology.
 
 A successful run with zero sparse calls is valid execution telemetry but is not evidence of SOL acceleration.
 
 ## Release notes
 
-See [CHANGELOG.md](CHANGELOG.md) for the v0.1.2 release summary and validation boundaries.
+See [CHANGELOG.md](CHANGELOG.md) for the v0.1.3 release summary and validation boundaries.
 
 `sol_h3/sol_manifest.json` records original upstream hashes and packaged hashes. `tools/rectangular_sm120.patch` records the functional rectangular changes after import adaptation.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,75 @@
+# ComfyUI-Sol-H3 v0.1.3
+
+Patch release restoring the conservative one-evaluation dense SOL warmup after a controlled same-seed video comparison exposed a startup trajectory discontinuity when SOL approximation was enabled from the first sigma-1.0 denoiser evaluation.
+
+## Default restored
+
+`Sol-H3 SOL Attention (Experimental)` now defaults to:
+
+```text
+dense_evaluations = 1
+dense_layers      = 2
+```
+
+`dense_evaluations=1` keeps the first complete denoiser evaluation on inherited dense attention before switching to SOL. `dense_layers=2` remains a separate per-evaluation leading-layer policy and does not add a transformer NFE.
+
+`dense_evaluations=0` remains supported as an explicit maximum-speed mode. This release changes the default because of a demonstrated quality risk; it does not remove the SOL-first path.
+
+## Startup quality evidence
+
+A subsequent controlled same-seed video comparison established a concrete failure mode for `dense_evaluations=0`:
+
+- SOL from the first denoiser evaluation produced an abrupt opening pose/orientation change with heavy early motion smearing before settling into the opposite heading.
+- One initial dense evaluation preserved a continuous opening turn in the corresponding comparison.
+
+This demonstrates that SOL-first execution **can** destabilize the initial trajectory when approximate attention acts from sigma 1.0. The available pair does not establish the frequency of the artifact across seeds, prompts, references, resolutions or model variants, so the release does not claim that every `dense_evaluations=0` run is affected.
+
+## Spectrum and NFE trade-off
+
+The v0.1.2 scheduling analysis remains correct. A one-evaluation dense warmup creates a real numerical-backend transition:
+
+```text
+first actual evaluation: dense
+next numerical route:    SOL
+```
+
+Spectrum correctly invalidates incompatible forecasting history across that `dense -> sol` boundary. The first would-be forecast can therefore become an additional actual transformer NFE to establish a SOL-side anchor.
+
+The previous controlled hot evidence remains the measured performance trade-off:
+
+| Run | SOL | `dense_evaluations` | Logical | Actual | Forecast | H3 sampler | End-to-end |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `metrics_00321` | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
+| `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
+| `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
+
+`dense_evaluations=0` avoids the initial backend-history transition and restored `25 actual / 15 forecast` topology parity with the no-SOL control in that test. Relative to the otherwise-matched `dense_evaluations=1` SOL run, it removed one actual NFE and measured 20.80 s (5.9%) lower H3 sampler wall time and 20.37 s (5.1%) lower end-to-end wall time. Arithmetic-gate/calibration time also varied, so the structural result is the removed NFE; the entire wall-time delta must not be assigned to that NFE alone.
+
+Do not weaken Spectrum's history/receipt safety to recover the NFE while retaining a dense-to-SOL transition. The extra actual call is the correct safety consequence of changing numerical attention backends mid-trajectory.
+
+## Migration
+
+Existing saved workflows keep their serialized `dense_evaluations` value. Workflows created or saved under v0.1.2 can therefore remain at `0` after upgrading until the node value is changed explicitly.
+
+Recommended policy:
+
+```text
+dense_evaluations = 1   # default: conservative startup trajectory
+
+dense_evaluations = 0   # opt-in: maximum-speed SOL-first path
+                         # may save one Spectrum actual NFE
+                         # may cause visible startup discontinuity
+```
+
+## Documentation and tests
+
+- Restored `Config(backend="sol")` and the ComfyUI node default to `dense_evaluations=1`.
+- Added regression coverage for the restored default, the SOL-first opt-in and Flow continuation semantics.
+- Reworked `docs/DENSE_EVALUATIONS.md` around the speed/quality trade-off and saved-workflow migration behavior.
+- Updated README and changelog to keep the v0.1.2 timing result as historical performance evidence rather than a quality-equivalence claim.
+
+---
+
 # ComfyUI-Sol-H3 v0.1.2
 
 Patch release changing the default SOL trajectory policy so new workflows start SOL on the first real denoiser evaluation instead of burning a full dense evaluation before switching numerical backends.

--- a/docs/DENSE_EVALUATIONS.md
+++ b/docs/DENSE_EVALUATIONS.md
@@ -2,35 +2,42 @@
 
 ## Current default
 
-Starting with **v0.1.2**, `Sol-H3 SOL Attention (Experimental)` defaults to:
+Starting with **v0.1.3**, `Sol-H3 SOL Attention (Experimental)` defaults to:
 
 ```text
-dense_evaluations = 0
+dense_evaluations = 1
 dense_layers      = 2
 ```
 
-`dense_evaluations=0` means SOL is the numerical attention backend from the first real denoiser evaluation. `dense_layers=2` is unchanged: the first two H3 blocks of each otherwise-SOL evaluation remain dense. That per-layer policy does **not** add a transformer NFE.
+`dense_evaluations=1` keeps the first complete denoiser evaluation on the inherited dense attention backend and enables SOL afterward. `dense_layers=2` is separate: the first two H3 blocks of each otherwise-SOL evaluation remain dense. The per-layer policy does **not** add a transformer NFE.
 
-Existing saved workflows keep their serialized `dense_evaluations` value. The default change affects newly created nodes and programmatic `Config(backend="sol")` users.
+Existing saved workflows keep their serialized `dense_evaluations` value. In particular, workflows created or saved with the v0.1.2 default can remain at `0` after upgrading until the value is changed explicitly. The v0.1.3 default affects newly created nodes and programmatic `Config(backend="sol")` users.
 
-## Why the default changed
+## Why v0.1.3 restores one dense evaluation
 
-The v0.1.0/v0.1.1 default was `dense_evaluations=1`. With Spectrum enabled, that creates a real numerical-backend boundary:
+v0.1.2 changed the default from `1` to `0` after controlled timing showed a real Spectrum interaction:
 
 ```text
+dense_evaluations=1:
 first actual evaluation: dense
 next numerical route:    SOL
+
+Spectrum action:
+invalidate incompatible dense history
+establish a SOL-side actual anchor
 ```
 
-Spectrum correctly treats `dense -> sol` as incompatible forecasting history. The would-be first forecast therefore becomes an additional actual transformer evaluation so that Spectrum can establish a SOL-side anchor. The extra NFE is a consequence of the configured transition; it is not an intrinsic requirement of Sol-Attn.
+That `dense -> sol` numerical-backend transition can convert the first would-be Spectrum forecast into an additional actual transformer NFE. With `dense_evaluations=0`, backend history starts directly in `phase=sol`, so that extra actual NFE is avoided.
 
-The fix is **not** to weaken Spectrum's backend-history invariant. It is to avoid creating the unnecessary trajectory-level backend transition by default.
+The scheduling result remains valid. The default is being restored for **quality**, not because the NFE analysis was wrong.
 
-With `dense_evaluations=0`, backend history starts directly in `phase=sol`, so the first actual evaluation is already a valid SOL anchor and the normal Spectrum forecast topology is retained.
+A subsequent controlled same-seed video comparison exposed a concrete startup failure mode when approximate SOL attention acts from the first sigma-1.0 evaluation. With `dense_evaluations=0`, the generated subject showed an abrupt early pose/orientation transition and heavy motion smearing before settling into the opposite heading. With `dense_evaluations=1`, the corresponding opening motion was a continuous turn.
 
-## Controlled MiniMax-H3 evidence
+This pair establishes that `dense_evaluations=0` **can** destabilize the initial trajectory. It does not establish how frequently the artifact occurs across seeds, prompts, references, resolutions or model variants. Because the failure is visible and occurs at the trajectory start, v0.1.3 uses the conservative one-evaluation warmup as the default.
 
-The default change was evaluated in a same-seed, same-reference, same-resolution, same-prompt, same-sampler, same-workflow hot comparison with VDN disabled. Only the named component/policy changed.
+## Speed / quality trade-off
+
+The v0.1.2 controlled hot timing remains useful evidence for the aggressive mode. Same seed, references, resolution, prompt, sampler, sampling settings and workflow structure; VDN disabled:
 
 | Run | SOL | `dense_evaluations` | Logical | Actual NFE | Forecasts | H3 sampler | End-to-end |
 |---|---|---:|---:|---:|---:|---:|---:|
@@ -38,7 +45,7 @@ The default change was evaluated in a same-seed, same-reference, same-resolution
 | `metrics_00322` | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
 | `metrics_00323` | on | **0** | **40** | **25** | **15** | **332.56 s** | **380.57 s** |
 
-`metrics_00323` therefore restores exact NFE/forecast topology parity with the no-SOL control:
+`metrics_00323` restored exact NFE/forecast topology parity with the no-SOL control:
 
 ```text
 40 logical
@@ -50,45 +57,39 @@ high:    8 actual / 6 forecast
 probe:   2 actual / 0 forecast
 ```
 
-The run also reports `phase=sol` from the first backend-history diagnostic and `numerical_backend_transitions=0`.
+It also started backend history directly in `phase=sol` and reported `numerical_backend_transitions=0`.
 
-Relative to the otherwise-matched `dense_evaluations=1` SOL run (`metrics_00321`), the H3 sampler decreased by 20.80 s (5.9%) and end-to-end wall time by 20.37 s (5.1%). The first progressive chunk fell from 149.13 s to 130.61 s. Not all of that wall-time delta should be assigned to the removed NFE because arithmetic-gate/calibration time also varied materially between hot runs; the topology change itself is the defensible structural gain.
+Relative to `metrics_00321`, the SOL-first run removed one actual NFE and measured 20.80 s (5.9%) lower H3 sampler wall time and 20.37 s (5.1%) lower end-to-end time. Arithmetic-gate/calibration time also varied, so the structural result is the removed NFE; the entire wall-time delta must not be attributed to that NFE alone.
 
-The topology-matched SOL-vs-no-SOL comparison is cleaner:
+Against the topology-matched no-SOL control, the tested `dense_evaluations=0` SOL run measured 42.28 s (11.3%) lower sampler wall and 40.24 s (9.6%) lower end-to-end wall. That remains deployment-specific timing evidence, not a universal Sol-Attn percentage and not a quality-equivalence claim.
 
-```text
-metrics_00323 SOL, 25A/15F:     332.56 s sampler / 380.57 s end-to-end
-metrics_00322 no SOL, 25A/15F:  374.84 s sampler / 420.81 s end-to-end
-```
-
-That is a 42.28 s (11.3%) sampler reduction and a 40.24 s (9.6%) end-to-end reduction in this controlled hot pair. It remains one deployment-instance measurement, not a universal SOL percentage.
-
-## Quality boundary
-
-The same-seed `dense_evaluations=0` video was visibly different from the `dense_evaluations=1` output, as expected when approximate SOL attention is allowed to affect the trajectory from sigma 1.0. Manual inspection did **not** establish either output as better or worse.
-
-That is evidence against an obvious regression in this tested case, but it is not a statistical perceptual-equivalence result. Users who prefer the older conservative trajectory warmup can set:
+The supported choices are therefore:
 
 ```text
-dense_evaluations = 1
+dense_evaluations = 1   # default: conservative startup trajectory
+
+dense_evaluations = 0   # opt-in: maximum-speed SOL-first trajectory
+                         # may save one Spectrum actual NFE
+                         # may cause visible startup discontinuity
 ```
 
-and retain the previous behavior, including the Spectrum history boundary and possible extra actual NFE.
+Do not weaken Spectrum's backend-history invalidation to recover the NFE while keeping a dense-to-SOL transition. The additional actual call is the correct safety consequence of changing numerical attention backends mid-trajectory.
 
 ## `dense_layers` is separate
 
 `dense_evaluations` and `dense_layers` control different things:
 
-- `dense_evaluations`: whole denoiser evaluations that stay on the inherited dense attention backend before SOL is allowed.
+- `dense_evaluations`: complete denoiser evaluations that stay on inherited dense attention before SOL is allowed.
 - `dense_layers`: leading H3 blocks that remain dense inside every otherwise-SOL denoiser evaluation.
 
-v0.1.2 changes only the first default. `dense_layers=2` remains unchanged.
+v0.1.3 changes only the first default. `dense_layers=2` remains unchanged.
 
-The legacy `dense_warmup` telemetry field currently counts dense attention calls caused by either policy, so it can remain nonzero with `dense_evaluations=0`. For trajectory-history diagnosis, use the configured `dense_evaluations`, backend-history `phase`, `numerical_backend_transitions`, and the actual/forecast topology rather than interpreting `dense_warmup` as a count of full dense denoiser evaluations.
+The legacy `dense_warmup` telemetry field counts dense attention calls caused by either policy, so it cannot be interpreted as a count of full dense denoiser evaluations. For trajectory-history diagnosis, use the configured `dense_evaluations`, backend-history `phase`, `numerical_backend_transitions`, and actual/forecast topology.
 
 ## Compatibility and safety
 
 - Spectrum's numerical-backend history/receipt checks remain unchanged and fail closed across real route changes.
-- `dense_evaluations > 0` remains supported as an explicit user policy.
-- Flow progressive high-stage continuation handling for an explicit one-evaluation warmup remains supported; it prevents a trajectory-start warmup from being spuriously restarted at a known continuation boundary.
-- Unknown/malformed routing still executes actual/inherited attention rather than forecasting across an unproven numerical route.
+- `dense_evaluations=0` remains fully supported as an explicit performance policy; this release changes the default and documents its quality risk rather than banning the mode.
+- Flow progressive high-stage continuation handling remains supported and prevents a trajectory-start one-evaluation warmup from being spuriously restarted at a known continuation boundary.
+- Unknown or malformed routing still executes actual/inherited attention rather than forecasting across an unproven numerical route.
+- Saved workflows are not rewritten on upgrade. Audit the serialized node value if a workflow was created under v0.1.2 and startup continuity matters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-sol-h3"
-version = "0.1.2"
+version = "0.1.3"
 description = "Native ComfyUI MiniMax-H3 exact runtime and composable Sana Sol-Attn integration"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}

--- a/sol_h3/contracts.py
+++ b/sol_h3/contracts.py
@@ -13,7 +13,7 @@ class Config:
     exact: bool = True
     backend: str = "inherit"
     tau: float = 1.0
-    dense_evaluations: int = 0
+    dense_evaluations: int = 1
     dense_layers: int = 2
 
     def __post_init__(self):

--- a/sol_h3/nodes.py
+++ b/sol_h3/nodes.py
@@ -22,15 +22,15 @@ class SolH3Experimental:
         return {"required": {"model": ("MODEL",),
                 "exact_fusion": ("BOOLEAN", {"default": True}),
                 "tau": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 3.0, "step": 0.1}),
-                "dense_evaluations": ("INT", {"default": 0, "min": 0, "max": 100}),
+                "dense_evaluations": ("INT", {"default": 1, "min": 0, "max": 100}),
                 "dense_layers": ("INT", {"default": 2, "min": 0, "max": 100})}}
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
     CATEGORY = "model/optimizations/Sol-H3/experimental"
-    DESCRIPTION = "Approximate Sol-Attn through the packaged Sana CuTe kernel on eligible SM120 H3/VDN calls. The default starts SOL on the first denoiser evaluation; set dense_evaluations > 0 only for an explicit trajectory-level dense warmup. SOL kernel execution requires Linux/WSL2; unsupported calls fall back locally."
+    DESCRIPTION = "Approximate Sol-Attn through the packaged Sana CuTe kernel on eligible SM120 H3/VDN calls. The default keeps the first full denoiser evaluation dense for conservative startup trajectory stability. dense_evaluations=0 is an aggressive speed opt-in: with Spectrum it can avoid one actual NFE, but it may cause visible startup temporal discontinuities. SOL kernel execution requires Linux/WSL2; unsupported calls fall back locally."
 
-    def apply(self, model, exact_fusion=True, tau=1.0, dense_evaluations=0, dense_layers=2):
+    def apply(self, model, exact_fusion=True, tau=1.0, dense_evaluations=1, dense_layers=2):
         from .runtime import install
         return (install(model, Config(exact_fusion, "sol", tau, dense_evaluations, dense_layers)),)
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -5,26 +5,26 @@ from sol_h3.interop import dense_evaluation_warmup
 from sol_h3.nodes import SolH3Experimental
 
 
-def test_sol_default_starts_on_first_denoiser_evaluation():
+def test_sol_default_uses_one_dense_trajectory_evaluation():
     config = Config(backend="sol")
-    assert config.dense_evaluations == 0
+    assert config.dense_evaluations == 1
     assert config.dense_layers == 2
-    assert dense_evaluation_warmup(config, 0, {}) is False
-
-    inputs = SolH3Experimental.INPUT_TYPES()["required"]
-    assert inputs["dense_evaluations"][1]["default"] == 0
-    assert inputs["dense_layers"][1]["default"] == 2
-    assert signature(SolH3Experimental.apply).parameters["dense_evaluations"].default == 0
-
-
-def test_dense_evaluation_warmup_remains_an_explicit_opt_in():
-    config = Config(backend="sol", dense_evaluations=1)
     assert dense_evaluation_warmup(config, 0, {}) is True
     assert dense_evaluation_warmup(config, 1, {}) is False
 
+    inputs = SolH3Experimental.INPUT_TYPES()["required"]
+    assert inputs["dense_evaluations"][1]["default"] == 1
+    assert inputs["dense_layers"][1]["default"] == 2
+    assert signature(SolH3Experimental.apply).parameters["dense_evaluations"].default == 1
 
-def test_progressive_high_continuation_does_not_restart_single_eval_opt_in():
-    config = Config(backend="sol", dense_evaluations=1)
+
+def test_sol_first_remains_an_explicit_speed_opt_in():
+    config = Config(backend="sol", dense_evaluations=0)
+    assert dense_evaluation_warmup(config, 0, {}) is False
+
+
+def test_progressive_high_continuation_does_not_restart_single_eval_default():
+    config = Config(backend="sol")
     options = {
         "h3_flow_stage": "high",
         "h3_refinement": {


### PR DESCRIPTION
## Summary

Restore `dense_evaluations=1` as the Sol-H3 default and prepare v0.1.3.

v0.1.2 changed the default to `0` because removing the initial `dense -> sol` numerical-backend transition lets Spectrum keep its normal forecast topology and avoids one actual transformer NFE. That scheduling analysis remains correct.

A subsequent controlled same-seed video comparison exposed a concrete quality failure mode when approximate SOL attention acts from the first sigma-1.0 evaluation: the `dense_evaluations=0` output shows an abrupt opening pose/orientation transition with heavy early smearing, while the corresponding `dense_evaluations=1` output keeps a continuous turn.

This PR therefore restores the conservative startup policy without weakening Spectrum and without removing the faster SOL-first path.

## Behavior

```text
dense_evaluations = 1   # default / conservative startup trajectory
dense_evaluations = 0   # explicit maximum-speed opt-in
dense_layers      = 2   # unchanged
```

`dense_evaluations=0` remains supported. With Spectrum it can avoid one actual NFE by starting backend history directly in `phase=sol`, but it now carries an explicit startup-continuity warning.

## Existing timing evidence

The v0.1.2 controlled hot measurements remain the speed trade-off:

| Run | SOL | dense_evaluations | Logical | Actual | Forecast | H3 sampler | End-to-end |
|---|---|---:|---:|---:|---:|---:|---:|
| metrics_00321 | on | 1 | 40 | 26 | 14 | 353.36 s | 400.94 s |
| metrics_00322 | off | — | 40 | 25 | 15 | 374.84 s | 420.81 s |
| metrics_00323 | on | 0 | 40 | 25 | 15 | 332.56 s | 380.57 s |

The structural difference is one additional actual NFE for the conservative dense-to-SOL transition. The full wall-time delta is not attributed solely to that NFE because arithmetic-gate/calibration time also varied.

## Safety / migration

- Spectrum history/receipt invalidation is unchanged.
- Do not bypass the dense-to-SOL history boundary to recover the NFE.
- `dense_evaluations=0` remains an explicit supported policy.
- `dense_layers=2` is unchanged.
- Flow progressive continuation still prevents the trajectory-start warmup from restarting at the high-stage continuation.
- Existing saved workflows retain their serialized value; workflows created under v0.1.2 can remain at `0` until changed explicitly.

## Release scope

- restore code and node defaults to `1`
- update regression tests
- rewrite `docs/DENSE_EVALUATIONS.md` around the speed/quality trade-off
- update README and changelog
- prepare v0.1.3 release notes
- bump package version to `0.1.3`

Checkpoint before the rewrite: `checkpoint/pre-v0.1.3-dense-default-revert-20260909` at the pre-change main state.