### PR TITLE
Make public documentation self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ See `docs/DENSE_EVALUATIONS.md` for the scheduling rationale, timing interpretat
 
 ## v0.1.1 — 2026-09-09
 
-Patch release for native-Windows installation/provenance behavior reported in issue #4.
+Patch release correcting native-Windows installation/provenance behavior and defining the supported fallback boundary for custom kernels.
 
 ### Fixed
 
@@ -74,13 +74,11 @@ Patch release for native-Windows installation/provenance behavior reported in is
 - Scopes the CuTe/Triton runtime toolchain dependencies to Linux, matching the supported/validated custom-kernel platforms.
 - Reports the Linux/WSL2 requirement explicitly when native Windows cannot provide the required `cute_sm120` backend.
 - Fails Exact Runtime closed on native Windows before importing/executing the Triton affine kernel and delegates to the untouched native H3 block (`exact:native_windows_unvalidated`).
-- Adds `docs/WINDOWS.md` with the supported-platform boundary and AIMDO isolation procedure.
+- Adds `docs/WINDOWS.md` with standalone native-Windows support, fallback and troubleshooting guidance.
 
-### Scope and remaining boundary
+### Platform boundary
 
-RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support native Windows. The real SOL `cute_sm120` kernel therefore still requires Linux/WSL2; v0.1.1 does not claim native-Windows SOL acceleration.
-
-The issue #4 v0.1.0 request reached `sparse_calls=0` / `sol_backend=null` and later failed inside `comfy_aimdo.malloc_graph_pop`, while Exact Runtime had executed (`exact_blocks=600`). v0.1.1 does not claim that Sol-H3 caused the AIMDO access violation. Instead, native Windows now automatically runs neither Sol-H3 custom kernel path: SOL falls back dense because CuTe is unavailable and Exact Runtime delegates to native H3. A remaining AIMDO crash after upgrading is therefore separable from Sol-H3 kernel execution.
+The real SOL `cute_sm120` kernel requires Linux/WSL2 because NVIDIA's current CUTLASS CuTe DSL does not support native Windows. On native Windows, SOL delegates to inherited dense attention and Exact Runtime delegates to native H3, so no Sol-H3 custom kernel executes there.
 
 The Linux/WSL SM120 production kernel contract and previously validated rectangular/VDN/Flow/Spectrum behavior are unchanged.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The release has three parts:
 
 Unvalidated combinations are experimental telemetry rather than blanket errors. Hard failures are reserved for broken contracts, unsafe geometry/indexing, failed arithmetic verification or real execution failures.
 
-> **Native Windows:** RTX 5090 is SM120 hardware, but NVIDIA's current CUTLASS CuTe DSL does not support Windows. The real `cute_sm120` SOL kernel therefore requires Linux/WSL2. v0.1.1 fixed Windows provenance/install diagnostics, falls SOL back to inherited dense attention, and fails Exact Runtime closed to untouched native H3 before its Triton affine kernel can execute. It does not claim native-Windows SOL acceleration. See [Native Windows status](docs/WINDOWS.md).
+> **Native Windows:** the current custom SOL and Exact Runtime kernel paths are not supported execution targets. SOL delegates to inherited dense attention and Exact Runtime delegates to native H3, so the nodes can remain in a workflow but no Sol-H3 custom kernel executes. Use Linux/WSL2 on supported hardware for custom-kernel acceleration. See [Native Windows status](docs/WINDOWS.md).
 
 ## v0.1.3 default: one dense trajectory evaluation
 
@@ -296,7 +296,7 @@ python -m ruff check .
 python -m pytest -q
 ```
 
-GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). The v0.1.3 trajectory-warmup decision, historical timing evidence and startup-quality boundary are documented in [DENSE_EVALUATIONS](docs/DENSE_EVALUATIONS.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows provenance and AIMDO isolation guidance is in [WINDOWS](docs/WINDOWS.md).
+GPU validation and production telemetry are documented in [VALIDATION](docs/VALIDATION.md). The v0.1.3 trajectory-warmup decision, historical timing evidence and startup-quality boundary are documented in [DENSE_EVALUATIONS](docs/DENSE_EVALUATIONS.md). Rectangular ownership, zero-copy layout behavior and approximation boundaries are documented in [RECTANGULAR](docs/RECTANGULAR.md). Source/interoperability provenance is in [AUDIT](docs/AUDIT.md). Native-Windows support, fallback behavior and troubleshooting are in [WINDOWS](docs/WINDOWS.md).
 
 Useful counters include:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -137,34 +137,28 @@ The existing `dense_warmup` telemetry field counts attention calls kept dense by
 
 # ComfyUI-Sol-H3 v0.1.1
 
-Patch release addressing the native-Windows failure reported in issue #4 without claiming unsupported native-Windows SOL kernel execution.
+Patch release correcting native-Windows installation/provenance behavior and defining the supported fallback boundary for custom kernels.
 
 ## Fixed
 
-- Fixed a real cross-platform provenance bug: vendored Sana file names are now compared with canonical `/` manifest paths instead of platform-native `Path` strings. A valid Windows checkout no longer fails every nested entry with `Packaged Sana source file set mismatch`.
+- Fixed a cross-platform provenance bug: vendored Sana file names are compared with canonical `/` manifest paths instead of platform-native `Path` strings, so valid Windows checkouts are not rejected because of path-separator formatting.
 - Pinned the vendored source snapshot to LF checkout via `.gitattributes`.
-- Provenance hashing now accepts only Git-style CRLF-to-LF transport normalization in addition to exact bytes; any other content change still fails closed.
+- Provenance hashing accepts only Git-style CRLF-to-LF transport normalization in addition to exact bytes; any other content change still fails closed.
 - Added `windows-latest` provenance CI covering Windows path semantics, CRLF normalization and tamper rejection.
-- Scoped CuTe/Triton runtime dependencies to Linux, matching the platform actually supported by the packaged kernel path.
-- Native Windows now reports an explicit `Linux/WSL2` requirement when the SM120 CuTe backend is unavailable instead of presenting the fallback as a generic backend-selection problem.
-- Exact Runtime now fails closed on native Windows before importing or executing its Triton affine kernel and delegates to the untouched native H3 block. This removes the unvalidated Sol-H3 Exact/Triton path from ComfyUI's native-Windows AIMDO malloc-graph lifecycle.
+- Scoped CuTe/Triton runtime dependencies to Linux, matching the platform supported by the packaged custom-kernel path.
+- Native Windows reports an explicit `Linux/WSL2` requirement when the SM120 CuTe backend is unavailable.
+- Exact Runtime fails closed on native Windows before importing or executing its Triton affine kernel and delegates to the untouched native H3 block.
 
 ## Native Windows boundary
 
-RTX 5090 is SM120 hardware and is architecturally eligible for the packaged kernel. The current NVIDIA CUTLASS CuTe DSL runtime does not support Windows, so the real `cute_sm120` SOL kernel still requires Linux/WSL2. This release fixes Windows installation/provenance behavior and diagnostics; it does **not** claim native-Windows SOL acceleration.
+The real `cute_sm120` SOL kernel requires Linux/WSL2 because NVIDIA's current CUTLASS CuTe DSL does not support native Windows. On native Windows, SOL delegates to inherited dense attention and Exact Runtime delegates to native H3, so no Sol-H3 custom kernel executes there.
 
 Official NVIDIA references:
 
 - https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/limitations.html
 - https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/quick_start.html
 
-See `docs/WINDOWS.md` for the exact boundary and troubleshooting procedure.
-
-## Issue #4 allocator crash
-
-The attached failing request reported `sol_backend=null`, `sol_source_tree_verified=false` and `sparse_calls=0`, so no SOL sparse kernel executed before the later `comfy_aimdo` `malloc_graph_pop` access violation. The same v0.1.0 request had `exact_fusion=true` and `exact_blocks=600`, so Exact Runtime was the only Sol-H3 custom kernel path that actually executed.
-
-v0.1.1 does not claim that Sol-H3 caused the AIMDO failure. Instead, native Windows now automatically delegates Exact Runtime to native H3, while SOL remains a dense fallback because CuTe is unavailable. If `comfy_aimdo` still fails after upgrading to v0.1.1, the failure is reproducible with both Sol-H3 custom kernel paths absent and should be investigated in the ComfyUI/AIMDO path separately.
+See `docs/WINDOWS.md` for the current platform boundary and troubleshooting guidance.
 
 ## Regression scope
 

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,10 +1,12 @@
 # Native Windows status
 
+Sol-H3 can be installed on native Windows, but its custom SOL and Exact Runtime kernel paths are not supported execution targets there. The nodes remain usable because both paths fail closed to native/inherited execution rather than requiring workflow changes.
+
 ## SOL attention
 
-RTX 5090 is an SM120 GPU, so the hardware architecture is eligible for the packaged Sana Sol-Attn path. The current NVIDIA CUTLASS CuTe DSL runtime is the limiting component on native Windows: NVIDIA documents Windows support as unsupported and the CuTe DSL quick-start currently lists Linux x86_64/aarch64 as the supported platforms.
+The packaged SOL path uses NVIDIA CUTLASS CuTe DSL for the `cute_sm120` backend. NVIDIA currently documents CuTe DSL Windows support as unsupported and lists Linux x86_64/aarch64 as the supported platforms.
 
-For the real `cute_sm120` SOL kernel, use Linux or WSL2. Native Windows is not a supported SOL-kernel execution target in this release. When CuTe is unavailable on native Windows, Sol-H3 falls back locally to the inherited dense attention provider and reports an explicit `native Windows ... requires Linux/WSL2` compatibility reason.
+For real SOL custom-kernel execution, use Linux or WSL2 on supported SM120 hardware. On native Windows, Sol-H3 delegates SOL attention to the inherited dense attention provider and records an explicit compatibility fallback instead of attempting an unsupported CuTe execution path.
 
 Official NVIDIA references:
 
@@ -13,44 +15,43 @@ Official NVIDIA references:
 
 ## Exact Runtime
 
-The Exact Runtime affine path uses a Triton kernel. It is production-validated on Linux/WSL, not native Windows. v0.1.1 therefore fails this optimization closed on `sys.platform == "win32"`: `ineligible_reason()` returns `native_windows_unvalidated` before the Triton kernel is imported or executed, and the normal untouched MiniMax-H3 block runs instead.
-
-This is intentional. A third-party native-Windows Triton build plus ComfyUI's AIMDO malloc-graph compiler is not an execution contract validated by this project. WSL2/Linux continues to use the existing Exact Runtime path unchanged.
-
-## Issue #4: `Packaged Sana source file set mismatch`
-
-The original v0.1.0 provenance verifier used `str(Path.relative_to(...))` to compare on-disk vendored paths with manifest keys. That produces backslashes on Windows while the manifest uses canonical forward-slash paths, so a valid Windows checkout could reject the complete vendored source tree before SOL initialization.
-
-v0.1.1 fixes that bug by using POSIX manifest keys on every platform. It also:
-
-- pins the vendored snapshot to LF checkout in `.gitattributes`;
-- accepts only Git-style CRLF-to-LF transport normalization when validating canonical packaged hashes;
-- keeps every other file-content difference fail-closed;
-- scopes CuTe/Triton runtime dependencies to Linux so native-Windows installation does not try to install an unsupported/unvalidated custom-kernel toolchain;
-- runs provenance regression tests on `windows-latest` CI.
-
-This fixes the false provenance failure. It does **not** claim native-Windows CuTe execution support.
-
-## `comfy_aimdo` / allocator crashes
-
-An error such as:
+The Exact Runtime affine path uses a Triton kernel and is production-validated on Linux/WSL2, not native Windows. On `sys.platform == "win32"`, Exact Runtime is therefore marked ineligible before its Triton kernel is imported or executed. The untouched MiniMax-H3 block runs instead and telemetry records:
 
 ```text
-OSError: exception: access violation reading 0x0000000000000000
-...
-comfy_aimdo.malloc_graph ... malloc_graph_pop
-RuntimeError: aimdo memory compile error
+exact:native_windows_unvalidated
 ```
 
-is a separate execution path from Sol-Attn. In issue #4 the final v0.1.0 Sol-H3 telemetry showed:
+This keeps native-Windows execution on the supported MiniMax-H3 path rather than depending on an unvalidated third-party Windows Triton runtime.
+
+## Installation behavior
+
+The custom-kernel runtime dependencies are scoped to Linux. Native-Windows installation therefore does not attempt to install the CuTe/Triton/CUDA-Python/TVM-FFI stack used by the Linux/WSL2 custom-kernel path.
+
+The vendored Sana source verifier is platform-independent:
+
+- manifest paths are canonical POSIX-style paths on every operating system;
+- the repository pins vendored source files to LF checkout;
+- provenance hashing accepts exact packaged bytes or Git-style CRLF-to-LF transport normalization;
+- every other file-content difference still fails closed.
+
+## Troubleshooting
+
+### `Packaged Sana source file set mismatch`
+
+A current checkout should not fail solely because Windows renders filesystem separators differently. If this error appears, update the node checkout first and verify that the vendored files have not been locally modified. The verifier reports missing and unexpected paths to make actual source-tree drift distinguishable from platform formatting.
+
+### `comfy_aimdo` or allocator errors
+
+Allocator failures are not, by themselves, evidence that a Sol-H3 custom kernel executed. Use Sol-H3 telemetry to identify the actual route.
+
+On native Windows, the expected state is:
 
 ```text
-sol_backend: null
-sol_source_tree_verified: false
 sparse_calls: 0
-exact_blocks: 600
+SOL: inherited dense fallback
+Exact Runtime: exact:native_windows_unvalidated
 ```
 
-Therefore no SOL sparse kernel executed in that failing request. The same request had `exact_fusion=true`, so Exact Runtime was the only Sol-H3 custom kernel path that actually executed. The log does not establish that either Sol-H3 or AIMDO was the root cause.
+If an allocator or `comfy_aimdo` failure occurs with that state, neither Sol-H3 custom kernel path executed and the allocator failure should be investigated in the ComfyUI/AIMDO path separately.
 
-v0.1.1 removes that ambiguity on native Windows: SOL cannot execute CuTe and falls back dense, while Exact Runtime automatically delegates to native H3 before importing or executing its Triton affine kernel. If `comfy_aimdo` still crashes after upgrading to v0.1.1, capture the new log. A failure with `sparse_calls=0` and `compatibility_fallbacks` containing `exact:native_windows_unvalidated` is evidence that neither Sol-H3 custom kernel path executed, so the remaining crash should be investigated in the ComfyUI/AIMDO path separately.
+If telemetry instead shows a Sol-H3 custom kernel executing on native Windows, include the complete telemetry and environment details in a bug report because that is outside the supported platform contract.


### PR DESCRIPTION
## Problem

The public documentation had issue-local context embedded as if every reader already knew the original report. In particular, the README and Windows documentation named a specific GPU and referred back to issue-specific telemetry. That is inappropriate for standalone user documentation.

## Fix

- remove the issue-specific GPU reference from the README;
- describe native-Windows behavior in terms of the actual supported platform/runtime contract only;
- rewrite `docs/WINDOWS.md` as standalone platform/support/troubleshooting documentation;
- remove issue-number and one-off telemetry narrative from the v0.1.1 changelog/release-note history while preserving the actual technical fix and platform boundary;
- keep concrete hardware names only where they are legitimate validation/performance evidence for an explicitly documented test setup.

## Documentation rule

Public docs must be understandable without hidden conversational/issue context. Historical context belongs in the issue/PR thread unless it is necessary to understand a stable public contract.

Topology: one documentation commit on top of current `main`.