### PR TITLE
Add generic weighted Mixed-Grid attention measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@v4
         with:
-          repository: Comfy-Org/ComfyUI
-          ref: efa6c8f804bff78b46a0fd458ebd2e47bba07a30
+          repository: xmarre/ComfyUI
+          ref: 8406da920f9df19cbc14b76aef1bcd3dc4cf1119
           path: _deps/ComfyUI
           persist-credentials: false
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: xmarre/ComfyUI-Spectrum-MiniMax-H3
-          ref: 9c682c07f4c5ea9de601cda234755a1561b59f59
+          ref: 78a9a5b36c185a55af59a44c073bc7f8e534bc97
           path: _deps/Spectrum
           persist-credentials: false
       - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: xmarre/MiniMax-H3-Flow-Aligned-Regenerate
-          ref: d2bbebcaeac235cd3a61d41213a58263c0257aa9
+          ref: 8dfb7a2e570458b5078734755b897c7e89ddac8c
           path: _deps/Flow
           persist-credentials: false
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
       - run: pip install torch==2.10.0+cpu torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
       - run: pip install -r _deps/ComfyUI/requirements.txt
       - run: pip install -e '.[test]'
-      - run: python -m pytest -q tests/test_sana_contract.py tests/test_real_comfy_interop.py tests/test_spectrum_stack.py tests/test_real_diffaid_stack.py tests/test_flow_mixed_history.py tests/test_flow_mixed_measure_contract.py
+      - run: python -m pytest -q tests/test_sana_contract.py tests/test_real_comfy_interop.py tests/test_spectrum_stack.py tests/test_real_diffaid_stack.py tests/test_flow_mixed_history.py tests/test_flow_mixed_measure_contract.py tests/test_weighted_measure_routes.py tests/test_flow_weighted_measure_contract.py
         env:
           COMFYUI_PATH: ${{ github.workspace }}/_deps/ComfyUI
           KJNODES_PATH: ${{ github.workspace }}/_deps/KJNodes

--- a/sol_h3/_vendor/sol_attn/interface.py
+++ b/sol_h3/_vendor/sol_attn/interface.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import functools
+import math
 
 import torch
 
@@ -200,12 +201,13 @@ def _compile_sm120(
     sink_start_block,
     sink_end_block,
     stream,
+    key_bias_enabled,
 ):
     import cutlass.cute as cute
 
     from .sm120 import make_kernel
 
-    operator = make_kernel()
+    operator = make_kernel(key_bias_enabled=key_bias_enabled)
     args = _to_cute_tensors(tensors)
     compiled = cute.compile(
         operator,
@@ -233,6 +235,7 @@ def _sol_attn_cute(
     sink_tokens,
     sink_start,
     valid_tokens=None,
+    key_bias=None,
 ):
     from .preprocess import prepare
 
@@ -263,7 +266,10 @@ def _sol_attn_cute(
         # supply views into an interleaved packed QKV buffer; never reuse a compiled contiguous
         # descriptor for a strided view (or vice versa).
         layout_key = tuple(tuple(int(s) for s in x.stride()) for x in (q, k, v))
-        key = (q.device.index, arch, batch, capacity_tokens, k.shape[1], heads, kv_splits, layout_key)
+        key = (
+            q.device.index, arch, batch, capacity_tokens, k.shape[1], heads, kv_splits,
+            layout_key, key_bias is not None,
+        )
 
         if arch == (9, 0):
             if sink_tokens:
@@ -346,7 +352,8 @@ def _sol_attn_cute(
                 sink_start,
                 sink_tokens,
             )
-            tensors = [q, k, v, output, kc, vc, threshold, lse]
+            key_bias_arg = key_bias if key_bias is not None else threshold
+            tensors = [q, k, v, output, kc, vc, threshold, key_bias_arg, lse]
             compiled = _compiled.get(key)
             if compiled is None:
                 compiled, args = _compile_sm120(
@@ -356,6 +363,7 @@ def _sol_attn_cute(
                     sink_start_block,
                     sink_end_block,
                     stream,
+                    key_bias is not None,
                 )
             else:
                 args = _to_cute_tensors(tensors)
@@ -434,6 +442,7 @@ def sol_attn(
     sink_tokens: int = 0,
     sink_start: int | None = None,
     compile_bucket_size: int | None = None,
+    key_bias: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Compute noncausal Sol-Attn for innermost-contiguous BF16 BTHD tensors.
 
@@ -453,6 +462,16 @@ def sol_attn(
     if kv_splits not in (1, 2, 4):
         raise ValueError("kv_splits must be 1, 2, or 4")
     backend = _backend_for_arch(arch)
+    if key_bias is not None:
+        if backend != "cute_sm120":
+            raise ValueError("key_bias is currently supported by cute_sm120 only")
+        if (not torch.is_tensor(key_bias) or key_bias.ndim != 1
+                or key_bias.shape[0] != k.shape[1] or key_bias.device != q.device
+                or key_bias.dtype != torch.float32 or not key_bias.is_contiguous()):
+            raise ValueError("key_bias must be contiguous float32 with one natural-log value per K/V row")
+        weighted_scale = q.shape[-1] ** -0.5 if scale is None else float(scale)
+        if not math.isfinite(weighted_scale) or weighted_scale <= 0.0:
+            raise ValueError("weighted Sol-Attn requires a finite positive attention scale")
     if q.shape[1] != k.shape[1] and backend != "cute_sm120":
         raise ValueError("Rectangular attention currently requires cute_sm120")
     valid_tokens = q.shape[1]
@@ -495,6 +514,7 @@ def sol_attn(
         sink_tokens=sink_tokens,
         sink_start=sink_start,
         valid_tokens=valid_tokens,
+        key_bias=key_bias,
     )
 
 

--- a/sol_h3/_vendor/sol_attn/sm120/kernel.py
+++ b/sol_h3/_vendor/sol_attn/sm120/kernel.py
@@ -8,11 +8,13 @@ def make_kernel(
     debug_route_trace: bool = False,
     prefetch_first_exact_k: bool = True,
     prefetch_next_route_k: bool = True,
+    key_bias_enabled: bool = False,
 ):
     return SolAttnForwardSm120(
         debug_route_trace=debug_route_trace,
         prefetch_first_exact_k=prefetch_first_exact_k,
         prefetch_next_route_k=prefetch_next_route_k,
+        key_bias_enabled=key_bias_enabled,
     )
 
 

--- a/sol_h3/_vendor/sol_attn/sm120/mainloop.py
+++ b/sol_h3/_vendor/sol_attn/sm120/mainloop.py
@@ -45,6 +45,7 @@ class SolAttnForwardSm120:
         debug_route_trace: bool = False,
         prefetch_first_exact_k: bool = True,
         prefetch_next_route_k: bool = True,
+        key_bias_enabled: bool = False,
     ):
         self.dtype = cutlass.BFloat16
         self.acc_dtype = cutlass.Float32
@@ -56,6 +57,7 @@ class SolAttnForwardSm120:
         self.debug_route_trace = debug_route_trace
         self.prefetch_first_exact_k = prefetch_first_exact_k
         self.prefetch_next_route_k = prefetch_next_route_k
+        self.key_bias_enabled = key_bias_enabled
 
     @cute.kernel
     def kernel(
@@ -67,6 +69,7 @@ class SolAttnForwardSm120:
         mKC: cute.Tensor,
         mVC: cute.Tensor,
         mThreshold: cute.Tensor,
+        mKeyBias: cute.Tensor,
         mLSE: cute.Tensor,
         tma_atom_Q: cute.CopyAtom,
         tma_atom_K: cute.CopyAtom,
@@ -611,6 +614,11 @@ class SolAttnForwardSm120:
                 if block_len > N:
                     block_len = cutlass.Int32(N)
                 mask_exact_scores(tSrS, tScS, block_len, q_len)
+                if cutlass.const_expr(self.key_bias_enabled):
+                    add_exact_key_bias(
+                        tSrS, tScS, mKeyBias, exact_block, block_len, q_len,
+                        cutlass.Float32(1.4426950408889634) / scale_softmax_log2e,
+                    )
                 row_scale = online_softmax(
                     tSrS, max_m, sum_m, scale_softmax_log2e
                 )
@@ -698,6 +706,7 @@ class SolAttnForwardSm120:
         kc: cute.Tensor,
         vc: cute.Tensor,
         threshold: cute.Tensor,
+        key_bias: cute.Tensor,
         lse: cute.Tensor,
         softmax_scale: cutlass.Float32,
         sink_start_block: cutlass.Int32,
@@ -872,6 +881,7 @@ class SolAttnForwardSm120:
             tma_tensor_KC,
             tma_tensor_VC,
             threshold,
+            key_bias,
             lse_target,
             tma_atom_Q,
             tma_atom_K,
@@ -1032,6 +1042,31 @@ def mask_exact_scores(
         for n in cutlass.range_constexpr(cute.size(scores_mn, mode=[1])):
             if (not valid_row) or coords_mn[m, n][1] >= block_len:
                 scores_mn[m, n] = -cutlass.Float32.inf
+
+
+@cute.jit
+def add_exact_key_bias(
+    scores: cute.Tensor,
+    coords: cute.Tensor,
+    key_bias: cute.Tensor,
+    exact_block: cutlass.Int32,
+    block_len: cutlass.Int32,
+    q_len: cutlass.Int32,
+    inv_softmax_scale: cutlass.Float32,
+):
+    """Add natural-log key measure as b/scale to valid exact raw QK scores."""
+    scores_mn = layout_utils.reshape_acc_to_mn(scores)
+    coords_mn = layout_utils.reshape_acc_to_mn(coords)
+    for m in cutlass.range_constexpr(cute.size(scores_mn, mode=[0])):
+        valid_row = coords_mn[m, 0][0] < q_len
+        for n in cutlass.range_constexpr(cute.size(scores_mn, mode=[1])):
+            local_col = coords_mn[m, n][1]
+            if valid_row and local_col < block_len:
+                absolute_col = exact_block * cutlass.Int32(N) + local_col
+                scores_mn[m, n] = (
+                    cutlass.Float32(scores_mn[m, n])
+                    + cutlass.Float32(key_bias[absolute_col]) * inv_softmax_scale
+                )
 
 
 @cute.jit

--- a/sol_h3/interop.py
+++ b/sol_h3/interop.py
@@ -1,4 +1,5 @@
 """Small duck-typed contracts shared with optional attention/forecast providers."""
+
 from dataclasses import dataclass
 
 HISTORY_KEY = "attention_backend_history_v1"
@@ -10,18 +11,27 @@ VDN_PREPROCESS_KEY = "vdn_attention_preprocess_v1"
 SPECTRUM_EXTERNAL_RUNTIME_KEY = "spectrum_h3_external_patch_runtime"
 FLOW_STAGE_KEY = "h3_flow_stage"
 FLOW_REFINEMENT_KEY = "h3_refinement"
+ATTENTION_MEASURE_KEY = "attention_measure_v1"
 
 
 def provider_name(provider):
     if provider is None:
         return "comfy.default"
-    return f"{getattr(provider, '__module__', '<unknown>')}.{getattr(provider, '__qualname__', type(provider).__name__)}"
+    return (
+        f"{getattr(provider, '__module__', '<unknown>')}.{getattr(provider, '__qualname__', type(provider).__name__)}"
+    )
 
 
-def receipt(options, block, route):
+def receipt(options, block, route, *, measure_plan=None, call_token=None):
     sink = options.get(RECEIPTS_KEY)
-    if sink is not None:
+    if sink is None:
+        return
+    if measure_plan is None:
         sink.append(("sol_h3", block, route))
+        return
+    from .weighted_measure import receipt_fields
+
+    sink.append(("sol_h3", block, route, receipt_fields(measure_plan, call_token=call_token)))
 
 
 def _flow_progressive_high_continuation(options):
@@ -57,14 +67,8 @@ def dense_evaluation_warmup(config, evaluation, options):
     request-local because Sol cannot prove how many of those evaluations were
     consumed before an arbitrary handoff.
     """
-    continuation_consumed_default = bool(
-        config.dense_evaluations == 1
-        and _flow_progressive_high_continuation(options)
-    )
-    return bool(
-        evaluation < config.dense_evaluations
-        and not continuation_consumed_default
-    )
+    continuation_consumed_default = bool(config.dense_evaluations == 1 and _flow_progressive_high_continuation(options))
+    return bool(evaluation < config.dense_evaluations and not continuation_consumed_default)
 
 
 def _freeze_history_value(value):
@@ -72,8 +76,7 @@ def _freeze_history_value(value):
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, dict):
-        return tuple(sorted(
-            (str(key), _freeze_history_value(item)) for key, item in value.items()))
+        return tuple(sorted((str(key), _freeze_history_value(item)) for key, item in value.items()))
     if isinstance(value, (tuple, list)):
         return tuple(_freeze_history_value(item) for item in value)
     if isinstance(value, (set, frozenset)):
@@ -176,8 +179,13 @@ def _diffaid_replacement_identity(patch, options):
         return None
     config = getattr(patch, "config", None)
     fields = (
-        "strength", "sigma_start", "sigma_end", "sigma_ramp",
-        "token_weight_mode", "token_tail", "cond_only",
+        "strength",
+        "sigma_start",
+        "sigma_end",
+        "sigma_ramp",
+        "token_weight_mode",
+        "token_tail",
+        "cond_only",
     )
     if config is None or any(not hasattr(config, name) for name in fields):
         return None
@@ -378,8 +386,13 @@ class HistoryPolicy:
         # actual counters. A policy that cannot prove its next routing returns None;
         # Spectrum executes that call and does not forecast across opaque routing.
         from .runtime import _REQUEST
+
         state = _REQUEST.get()
         if state is None:
+            return None
+        # Generic weighted measure becomes forecastable only after Spectrum
+        # binds its completed-receipt identity companion.
+        if options.get(ATTENTION_MEASURE_KEY) is not None:
             return None
         replacements = options.get("patches_replace", {}).get("dit", {})
         replacement_identity = []
@@ -398,25 +411,101 @@ class HistoryPolicy:
                     return None
                 vdn.append(identity)
         signature = getattr(layout, "signature", None)
-        phase = "dense" if dense_evaluation_warmup(
-            self.config, state.evaluations, options
-        ) else "sol"
-        return (self.config.metadata()["fingerprint"], phase, repr(signature),
-                getattr(layout, "seq_len", None), tuple(getattr(layout, "segments", ())),
-                str(getattr(model, "dtype", None)), tuple(replacement_identity),
-                provider_identity(
-                    options.get("optimized_attention_override"),
-                    state.disabled_dense_providers,
-                ), tuple(vdn))
+        phase = "dense" if dense_evaluation_warmup(self.config, state.evaluations, options) else "sol"
+        return (
+            self.config.metadata()["fingerprint"],
+            phase,
+            repr(signature),
+            getattr(layout, "seq_len", None),
+            tuple(getattr(layout, "segments", ())),
+            str(getattr(model, "dtype", None)),
+            tuple(replacement_identity),
+            provider_identity(
+                options.get("optimized_attention_override"),
+                state.disabled_dense_providers,
+            ),
+            tuple(vdn),
+        )
 
     def accept_receipts(self, receipts):
-        return bool(receipts) and all(
-            len(item) == 3 and item[0] == "sol_h3" and item[2] in (
-                "sol", "sol_external_mixed", "sol_external_mixed_measure", "dense_warmup",
-                "vdn_local_sol", "vdn_dense_warmup",
-                "vdn_local_native", "vdn_global_native", "vdn_anchor_native",
-                "vdn_flex_masked_native", "external_sequence_native")
-            for item in receipts)
+        if not receipts:
+            return False
+        plain_routes = {
+            "sol",
+            "sol_external_mixed",
+            "sol_external_mixed_measure",
+            "dense_warmup",
+            "vdn_local_sol",
+            "vdn_dense_warmup",
+            "vdn_local_native",
+            "vdn_global_native",
+            "vdn_anchor_native",
+            "vdn_flex_masked_native",
+            "external_sequence_native",
+        }
+        from . import weighted_measure
+
+        for item in receipts:
+            if not isinstance(item, tuple) or len(item) not in {3, 4} or item[0] != "sol_h3":
+                return False
+            route = item[2]
+            if not isinstance(route, str):
+                return False
+            if len(item) == 3:
+                if route not in plain_routes:
+                    return False
+                continue
+
+            if route == "sol_external_mixed_weighted_measure":
+                expected_profile = weighted_measure.SPARSE_IMPLEMENTATION_PROFILE
+                expected_route = weighted_measure.SPARSE_NUMERICAL_ROUTE
+            elif route == "dense_warmup" or route.startswith("kernel_unavailable:"):
+                expected_profile = weighted_measure.DENSE_IMPLEMENTATION_PROFILE
+                expected_route = weighted_measure.DENSE_NUMERICAL_ROUTE
+            else:
+                return False
+
+            fields = item[3]
+            if not isinstance(fields, tuple) or len(fields) != 11:
+                return False
+            (
+                key,
+                call_token,
+                owner_generation,
+                semantic_digest,
+                implementation_profile,
+                numerical_route,
+                q_rows,
+                kv_rows,
+                exact_range_digest,
+                preprocess_digest,
+                completed,
+            ) = fields
+            if (
+                key != ATTENTION_MEASURE_KEY
+                or not isinstance(call_token, tuple)
+                or len(call_token) != 2
+                or call_token[0] != "sol_h3_evaluation"
+                or type(call_token[1]) is not int
+                or call_token[1] < 0
+                or not isinstance(owner_generation, str)
+                or not owner_generation
+                or not isinstance(semantic_digest, str)
+                or not semantic_digest
+                or implementation_profile != expected_profile
+                or numerical_route != expected_route
+                or type(q_rows) is not int
+                or q_rows <= 0
+                or type(kv_rows) is not int
+                or kv_rows <= 0
+                or not isinstance(exact_range_digest, str)
+                or not exact_range_digest
+                or not isinstance(preprocess_digest, str)
+                or not preprocess_digest
+                or completed is not True
+            ):
+                return False
+        return True
 
 
 def provider_identity(provider, disabled_dense_providers=()):

--- a/sol_h3/provenance.py
+++ b/sol_h3/provenance.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 SOURCE = 'sana-sol-engine'
 REVISION = '2936c47637380842aaa4a4488fac5006cc542b70'
-CONTRACT = 'sana-sol-engine-sol-attn-64-rect-sm120-v2'
+CONTRACT = 'sana-sol-engine-sol-attn-64-rect-sm120-v3'
 
 
 def _manifest_name(path, source):

--- a/sol_h3/runtime.py
+++ b/sol_h3/runtime.py
@@ -6,6 +6,7 @@ import logging
 
 from .contracts import KEY, Config, adaln_status, prefix_length
 from .mixed_measure import FLOW_MIXED_MEASURE_KEY, reduce_kv, validate_measure_contract
+from . import weighted_measure
 from .interop import (
     HISTORY_KEY,
     VDN_KEY,
@@ -38,6 +39,11 @@ class Request:
     external_mixed_measure_kv_rows_before: int = 0
     external_mixed_measure_kv_rows_after: int = 0
     external_mixed_measure_removed_rows: int = 0
+    external_mixed_weighted_measure_calls: int = 0
+    external_mixed_weighted_measure_q_rows: int = 0
+    external_mixed_weighted_measure_kv_rows: int = 0
+    measure_plans: dict = field(default_factory=dict)
+    measure_biases: dict = field(default_factory=dict)
     vdn_local_sol_calls: int = 0
     vdn_rectangular_sol_calls: int = 0
     vdn_requested_q_rows: int = 0
@@ -95,6 +101,9 @@ class SamplingWrapper:
                         "external_mixed_measure_kv_rows_before": state.external_mixed_measure_kv_rows_before,
                         "external_mixed_measure_kv_rows_after": state.external_mixed_measure_kv_rows_after,
                         "external_mixed_measure_removed_rows": state.external_mixed_measure_removed_rows,
+                        "external_mixed_weighted_measure_calls": state.external_mixed_weighted_measure_calls,
+                        "external_mixed_weighted_measure_q_rows": state.external_mixed_weighted_measure_q_rows,
+                        "external_mixed_weighted_measure_kv_rows": state.external_mixed_weighted_measure_kv_rows,
                         "compatibility_fallbacks": dict(state.fallbacks),
                         "dense_provider_failures": dict(state.dense_provider_failures),
                         "vdn_local_sol_calls": state.vdn_local_sol_calls,
@@ -293,9 +302,9 @@ class BlockPatch:
         forwarded = {**args, "transformer_options": options}
         route_start = len(routes)
 
-        def record(route, fallback=False):
+        def record(route, fallback=False, measure_plan=None):
             routes.append((self.index, route))
-            receipt(options, self.index, route)
+            receipt(options, self.index, route, measure_plan=measure_plan, call_token=evaluation)
             if fallback:
                 state.fallbacks[route] += 1
 
@@ -367,7 +376,10 @@ class BlockPatch:
                     reason = "forecast_consumer_no_history_contract"
                 layout = current_options.get("minimax_h3_layout", args.get("layout"))
                 external_contract = current_options.get("vdn_h3_external_sequence_v1")
-                measure_contract = current_options.get(FLOW_MIXED_MEASURE_KEY)
+                legacy_measure_contract = current_options.get(FLOW_MIXED_MEASURE_KEY)
+                generic_measure_contract = current_options.get(weighted_measure.ATTENTION_MEASURE_KEY)
+                if legacy_measure_contract is not None and generic_measure_contract is not None:
+                    raise RuntimeError("legacy and generic Mixed-Grid attention-measure contracts cannot coexist")
                 external_mixed = False
                 prefix = 0
                 if reason is None and external_contract is not None:
@@ -379,22 +391,130 @@ class BlockPatch:
                     except RuntimeError:
                         reason = "packed_layout_not_representable"
 
-                # The independent Flow measure contract is meaningful only on a
-                # fully validated external mixed stream. Never silently drop or
-                # reinterpret a malformed measure request as the old square path.
-                if measure_contract is not None and (reason is not None or not external_mixed):
+                # The legacy representative-KV contract is coupled to VDN API 2
+                # because that contract describes its gather domain. The generic key-measure
+                # contract is not: it binds to the actual all-row H3 layout and only cross-checks
+                # VDN API 2 when that optional contract is present.
+                if legacy_measure_contract is not None and (reason is not None or not external_mixed):
                     raise RuntimeError(
-                        "Flow mixed-grid attention-measure contract requires a valid external mixed sequence"
+                        "Legacy Flow mixed-grid attention-measure contract requires a valid external mixed sequence"
+                    )
+                if generic_measure_contract is not None and reason is not None:
+                    raise RuntimeError(
+                        "Generic mixed-grid attention measure requires the actual representable H3 mixed layout"
                     )
                 if reason is not None:
                     record(reason, True)
                     return dense()
 
+                if generic_measure_contract is not None:
+                    state.eligible_calls += 1
+                    preprocess_identity = weighted_measure.preprocess_digest(dense_provider)
+                    existing_sink = (0, (int(prefix) + 63) // 64)
+                    bind_kwargs = {
+                        "block_index": self.index,
+                        "layout": layout,
+                        "q_rows": int(q.shape[2]),
+                        "kv_rows": int(k.shape[2]),
+                        "dtype": q.dtype,
+                        "device": q.device,
+                        "head_dim": int(q.shape[-1]),
+                        "existing_sink": existing_sink,
+                        "external_sequence": external_contract,
+                        "preprocess_identity": preprocess_identity,
+                    }
+                    if warmup:
+                        measure_plan = weighted_measure.prepare(
+                            state,
+                            current_options,
+                            generic_measure_contract,
+                            **bind_kwargs,
+                            implementation_profile=weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+                            numerical_route=weighted_measure.DENSE_NUMERICAL_ROUTE,
+                        )
+                    else:
+                        measure_plan = weighted_measure.prepare(
+                            state,
+                            current_options,
+                            generic_measure_contract,
+                            **bind_kwargs,
+                            implementation_profile=weighted_measure.SPARSE_IMPLEMENTATION_PROFILE,
+                            numerical_route=weighted_measure.SPARSE_NUMERICAL_ROUTE,
+                        )
+                    # Bind against the original mixed coordinates, then run the
+                    # full-domain preprocessing chain exactly once.
+                    q, k, v, dense_provider = _preprocess_chain(dense_provider, q, k, v, heads, kw)
+
+                    def weighted_dense_result(plan, *, output_heads=False, qd=q, kd=k, vd=v):
+                        return weighted_measure.dense(
+                            qd,
+                            kd,
+                            vd,
+                            heads,
+                            plan,
+                            scale=kw.get("scale"),
+                            output_heads=output_heads,
+                        )
+
+                    if warmup:
+                        result = weighted_dense_result(measure_plan)
+                        state.dense_calls += 1
+                        state.external_mixed_weighted_measure_calls += 1
+                        state.external_mixed_weighted_measure_q_rows += q.shape[2]
+                        state.external_mixed_weighted_measure_kv_rows += k.shape[2]
+                        record("dense_warmup", measure_plan=measure_plan)
+                        return result
+
+                    def weighted_prefix_dense(qd, kd, vd):
+                        out = weighted_dense_result(measure_plan, output_heads=True, qd=qd, kd=kd, vd=vd)
+                        if out.shape != qd.shape:
+                            raise RuntimeError("weighted dense prefix returned an invalid output shape")
+                        return out.transpose(1, 2)
+
+                    from .sparse import attention, KernelUnavailable
+
+                    try:
+                        result = attention(
+                            q,
+                            k,
+                            v,
+                            prefix,
+                            config,
+                            state,
+                            dense_attention=weighted_prefix_dense,
+                            key_bias=measure_plan.key_log_measure,
+                            exact_k_blocks=measure_plan.exact_k_block_range,
+                            calibration_identity=measure_plan.semantic_digest,
+                        )
+                    except KernelUnavailable as exc:
+                        dense_plan = weighted_measure.prepare(
+                            state,
+                            current_options,
+                            generic_measure_contract,
+                            **bind_kwargs,
+                            implementation_profile=weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+                            numerical_route=weighted_measure.DENSE_NUMERICAL_ROUTE,
+                        )
+                        result = weighted_dense_result(dense_plan)
+                        state.external_mixed_weighted_measure_calls += 1
+                        state.external_mixed_weighted_measure_q_rows += q.shape[2]
+                        state.external_mixed_weighted_measure_kv_rows += k.shape[2]
+                        record("kernel_unavailable:" + str(exc), True, measure_plan=dense_plan)
+                        return result
+                    state.external_mixed_sol_calls += 1
+                    state.external_mixed_q_rows += q.shape[2]
+                    state.external_mixed_kernel_q_rows += q.shape[2]
+                    state.external_mixed_weighted_measure_calls += 1
+                    state.external_mixed_weighted_measure_q_rows += q.shape[2]
+                    state.external_mixed_weighted_measure_kv_rows += k.shape[2]
+                    record("sol_external_mixed_weighted_measure", measure_plan=measure_plan)
+                    return result
+
                 measure_validated = None
                 measure_stats = None
-                if measure_contract is not None:
+                if legacy_measure_contract is not None:
                     measure_validated = validate_measure_contract(
-                        measure_contract,
+                        legacy_measure_contract,
                         external_contract,
                         q_rows=int(q.shape[2]),
                         kv_rows=int(k.shape[2]),
@@ -514,13 +634,12 @@ class BlockPatch:
                     sink_rows=sink_rows,
                 )
 
-            def vdn_preprocess(q, k, v, *, heads, transformer_options):
-                # VDN exposes post-RoPE [T,H,D]. Comfy attention preprocessors use
-                # [B,H,T,D], so adapt only at this explicit full-domain boundary.
-                qc, kc, vc = (t.transpose(0, 1).unsqueeze(0) for t in (q, k, v))
-                kw = {"transformer_options": transformer_options, "skip_reshape": True}
-                qc, kc, vc, _ = _preprocess_chain(previous, qc, kc, vc, heads, kw)
-                return tuple(t.squeeze(0).transpose(0, 1) for t in (qc, kc, vc))
+            def vdn_preprocess(q, k, v, heads, mask=None, **kw):
+                dense_kw = {**kw, "_inside_attn_wrapper": True}
+                if previous is None or not hasattr(previous, "attention_preprocess_v1"):
+                    return q, k, v
+                q, k, v, _ = _preprocess_chain(previous, q, k, v, heads, dense_kw)
+                return q, k, v
 
             options["optimized_attention_override"] = override
             options[VDN_KEY] = vdn_provider_v1
@@ -596,6 +715,7 @@ def install(model, config):
     to[KEY] = config.metadata()
     if config.backend == "sol":
         to[HISTORY_KEY] = {**to.get(HISTORY_KEY, {}), "sol_h3": HistoryPolicy(config)}
+        weighted_measure.register(to, refresh_owned=True)
     for kind, wrapper in (
         (WrappersMP.OUTER_SAMPLE, SamplingWrapper(config)),
         (WrappersMP.DIFFUSION_MODEL, DiffusionWrapper(config)),

--- a/sol_h3/sol_manifest.json
+++ b/sol_h3/sol_manifest.json
@@ -4,7 +4,8 @@
   "branch": "sol-engine",
   "revision": "2936c47637380842aaa4a4488fac5006cc542b70",
   "subtree": "models/minimax_h3/Sol-H3/h3_runtime/third_party/sol_attn",
-  "transformation": "relative-imports-v1; rectangular-sm120-v2 (tools/rectangular_sm120.patch)",
+  "transformation": "relative-imports-v1; rectangular-sm120-v3 (tools/rectangular_sm120.patch)",
+  "packaged_patch_sha256": "ca318d72e526ad22d5968c1d7d5182bf6bb4f10f2b89f74612a7f74cad4ce4c2",
   "files": {
     "THIRD_PARTY_NOTICES.md": {
       "upstream_sha256": "103d86cce2d458005c83713765880b0d48205faa4b7b20a774d36fc3df56da00",
@@ -100,16 +101,16 @@
     },
     "interface.py": {
       "upstream_sha256": "1801195ca718a7d1d1af5b0fc5e2c779a8a142f6f541afebc38433784243351e",
-      "packaged_sha256": "5189941d7534c8c139ed24838a7e519752f159a04bf2c6bcc0df2df373d4f29e",
+      "packaged_sha256": "cd278f6efbba842bec5684997925d7bd10746dd1f2da2758e18ac571e0666166",
       "modifications": [
-        "rectangular-sm120-v2"
+        "rectangular-sm120-v3"
       ]
     },
     "preprocess.py": {
       "upstream_sha256": "d38c924280e00c34072652cfedf6fd65c85db6a4fe93e7858dd919e28d89d958",
       "packaged_sha256": "97c9f5f3a9c491442b3298819153f090221305398379b55825db54e5b3aa28ec",
       "modifications": [
-        "rectangular-sm120-v2"
+        "rectangular-sm120-v3"
       ]
     },
     "sm100/LICENSE.flash-attention": {
@@ -146,13 +147,16 @@
     },
     "sm120/kernel.py": {
       "upstream_sha256": "cba5a94506cb15025faf7065340d36eba8747cff5a0852816486213fbd7fb715",
-      "packaged_sha256": "cba5a94506cb15025faf7065340d36eba8747cff5a0852816486213fbd7fb715"
+      "packaged_sha256": "03e7c3da49e2af2e75366765784fab809529ce461993068da96aedcfdefab9df",
+      "modifications": [
+        "rectangular-sm120-v3"
+      ]
     },
     "sm120/mainloop.py": {
       "upstream_sha256": "8b6b87be7fe21cb0ebfbab34cd0ae819faa96b829c57c7b27c1c14c29e771570",
-      "packaged_sha256": "6602a1c3467ef07a8cd8ee213eb7d9ef33b3a8cd258ad53bff401393e5196c89",
+      "packaged_sha256": "3568c456083fc1ebf468648628e8026507da6efcd3f256ca8cc5eccea965b2a6",
       "modifications": [
-        "rectangular-sm120-v2"
+        "rectangular-sm120-v3"
       ]
     },
     "sm90/__init__.py": {
@@ -219,6 +223,5 @@
       "upstream_sha256": "c1aaa53b26ac9293f504f1d107814ed6c1924a9b671ebebfffc54ec83f743264",
       "packaged_sha256": "c1aaa53b26ac9293f504f1d107814ed6c1924a9b671ebebfffc54ec83f743264"
     }
-  },
-  "packaged_patch_sha256": "cde382135ed205f6bacb88096b822c4ba19e63922d8418f8352a216d05432ee6"
+  }
 }

--- a/sol_h3/sparse.py
+++ b/sol_h3/sparse.py
@@ -23,21 +23,15 @@ class KernelUnavailable(RuntimeError):
 
 
 def _sink_blocks(start, tokens, rows):
-    """Validate an exact prefix interval and describe its overlapping 64-row blocks.
-
-    Sol-H3 only requests prefix sinks beginning at row zero. The final partial
-    block is intentionally rounded outward: this makes a few extra keys exact,
-    which is semantics-preserving and only slightly more expensive.
-    """
+    """Validate one exact K interval and return its overlapping 64-row blocks."""
     if type(start) is not int or type(tokens) is not int or type(rows) is not int:
         raise RuntimeError("SOL sink geometry must use integer row counts")
-    if start != 0:
-        raise RuntimeError("Sol-H3 currently supports only a prefix sink beginning at row zero")
-    if tokens < 0 or tokens > rows:
-        raise RuntimeError("SOL sink row count is outside the current sequence")
+    if start < 0 or tokens < 0 or rows < 0 or start > rows or start + tokens > rows:
+        raise RuntimeError("SOL sink row range is outside the current sequence")
     if tokens == 0:
-        return [0, 0]
-    return [0, (tokens + BLOCK_SIZE - 1) // BLOCK_SIZE]
+        block = start // BLOCK_SIZE
+        return [block, block]
+    return [start // BLOCK_SIZE, (start + tokens + BLOCK_SIZE - 1) // BLOCK_SIZE]
 
 
 def load_kernel(device):
@@ -65,11 +59,12 @@ def load_kernel(device):
         raise RuntimeError(f"Sana Sol-Attn initialization failed: {exc}") from exc
 
     def kernel(q, k, v, *, tau, thresh_type="diag", kv_splits=1,
-               sink_start=0, sink_tokens=0):
-        _sink_blocks(sink_start, sink_tokens, k.shape[1])  # validate prefix geometry
+               sink_start=0, sink_tokens=0, key_bias=None):
+        _sink_blocks(sink_start, sink_tokens, k.shape[1])
         return sol_attn(q, k, v, scale=q.shape[-1] ** -0.5, tau=float(tau),
                         thresh_type=thresh_type, kv_splits=kv_splits,
-                        sink_start=sink_start, sink_tokens=sink_tokens)
+                        sink_start=sink_start, sink_tokens=sink_tokens,
+                        key_bias=key_bias)
 
     kernel.backend_name = backend
     kernel.source_tree_verified = True
@@ -133,14 +128,20 @@ def arithmetic_gate_passes(metrics):
     )
 
 
-def _dense_reference(q, k, v, dense_attention):
+def _dense_reference(q, k, v, dense_attention, key_bias=None):
     if dense_attention is not None:
         out = dense_attention(q, k, v)
         expected = (q.shape[0], q.shape[2], q.shape[1], q.shape[3])
         if out.shape != expected:
             raise RuntimeError(f"Dense SOL reference returned {tuple(out.shape)}, expected {expected}")
         return out
-    return F.scaled_dot_product_attention(q, k, v).transpose(1, 2)
+    # ``attention_measure_v1`` deliberately owns an FP32 natural-log key vector,
+    # while production Sol-H3 Q/K/V are BF16. PyTorch SDPA requires an additive
+    # floating mask to match the query dtype on CUDA. Cast only the calibration
+    # view; the authoritative FP32 key-bias tensor remains unchanged for the CuTe
+    # weighted specialization and for plan/cache identity.
+    bias = None if key_bias is None else key_bias.to(dtype=q.dtype).view(1, 1, 1, -1)
+    return F.scaled_dot_product_attention(q, k, v, attn_mask=bias).transpose(1, 2)
 
 
 def _bthd_layout_key(*tensors):
@@ -149,7 +150,8 @@ def _bthd_layout_key(*tensors):
 
 
 def attention(q, k, v, prefix, config, state, dense_attention=None,
-              recompute_prefix_queries=True):
+              recompute_prefix_queries=True, key_bias=None, exact_k_blocks=None,
+              calibration_identity=None):
     if (any(x.ndim != 4 for x in (q, k, v)) or k.shape != v.shape
             or q.shape[:2] != k.shape[:2] or q.shape[-1] != k.shape[-1]
             or q.shape[0] != 1 or q.shape[-1] != 128
@@ -160,6 +162,21 @@ def attention(q, k, v, prefix, config, state, dense_attention=None,
         raise RuntimeError("Prefix query recomputation exceeds the available Q rows")
     if any(x.dtype != torch.bfloat16 or x.device != q.device for x in (q, k, v)):
         raise RuntimeError("SOL requires BF16 QKV on the same device")
+    if key_bias is not None:
+        if (not torch.is_tensor(key_bias) or key_bias.ndim != 1
+                or key_bias.shape[0] != k.shape[2] or key_bias.device != q.device
+                or key_bias.dtype != torch.float32 or not key_bias.is_contiguous()):
+            raise RuntimeError("weighted SOL requires contiguous FP32 key_bias with one value per K row")
+        if not isinstance(calibration_identity, str) or not calibration_identity:
+            raise RuntimeError("weighted SOL requires a semantic calibration identity")
+        if (not isinstance(exact_k_blocks, (tuple, list)) or len(exact_k_blocks) != 2
+                or any(type(x) is not int for x in exact_k_blocks)):
+            raise RuntimeError("weighted SOL requires one exact K block interval")
+        max_blocks = (k.shape[2] + BLOCK_SIZE - 1) // BLOCK_SIZE
+        if exact_k_blocks[0] < 0 or exact_k_blocks[1] < exact_k_blocks[0] or exact_k_blocks[1] > max_blocks:
+            raise RuntimeError("weighted SOL exact K block interval is out of range")
+    elif exact_k_blocks is not None or calibration_identity is not None:
+        raise RuntimeError("weighted SOL routing metadata was supplied without key_bias")
     kernel_loader_s = 0.0
     if state.kernel is None:
         failure = getattr(state, "kernel_failure", None)
@@ -183,7 +200,7 @@ def attention(q, k, v, prefix, config, state, dense_attention=None,
         raise RuntimeError("SOL BTHD bridge requires a contiguous head dimension")
 
     layout_key = _bthd_layout_key(qb, kb, vb)
-    key = (q.device, q.dtype, layout_key)
+    key = (q.device, q.dtype, layout_key, calibration_identity)
     calibrating = key not in state.sparse_verified
     gate_started = time.perf_counter() if calibrating else None
     if calibrating:
@@ -191,8 +208,8 @@ def attention(q, k, v, prefix, config, state, dense_attention=None,
         # hot path will reuse. error_metrics() already performs scalar reads, so
         # this adds no new steady-state synchronization point.
         got = state.kernel(qb, kb, vb, tau=config.tau, thresh_type="diag", kv_splits=1,
-                           sink_start=0, sink_tokens=kb.shape[1])
-        want = _dense_reference(q, k, v, None)
+                           sink_start=0, sink_tokens=kb.shape[1], key_bias=key_bias)
+        want = _dense_reference(q, k, v, None, key_bias=key_bias)
         metrics = error_metrics(got, want)
         gate_wall_s = time.perf_counter() - gate_started
         if not arithmetic_gate_passes(metrics):
@@ -210,11 +227,19 @@ def attention(q, k, v, prefix, config, state, dense_attention=None,
             **metrics,
         })
         del got, want
+    if exact_k_blocks is None:
+        sink_start, sink_tokens = 0, prefix
+    else:
+        sink_start = exact_k_blocks[0] * BLOCK_SIZE
+        sink_end = min(k.shape[2], exact_k_blocks[1] * BLOCK_SIZE)
+        sink_tokens = max(0, sink_end - sink_start)
     out = state.kernel(qb, kb, vb, tau=config.tau, thresh_type="diag", kv_splits=1,
-                       sink_start=0, sink_tokens=prefix)
+                       sink_start=sink_start, sink_tokens=sink_tokens, key_bias=key_bias)
     # Normal H3 replaces non-video query rows with the inherited dense provider.
     # VDN local Q contains only requested rows; sink_rows describes K/V only.
     if prefix and recompute_prefix_queries:
-        out[:, :prefix] = _dense_reference(q[:, :, :prefix], k, v, dense_attention)
+        out[:, :prefix] = _dense_reference(
+            q[:, :, :prefix], k, v, dense_attention, key_bias=key_bias
+        )
     state.sparse_calls += 1
     return out.reshape(1, q.shape[2], -1)

--- a/sol_h3/weighted_measure.py
+++ b/sol_h3/weighted_measure.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import hashlib
+import importlib
+import marshal
+import threading
+import uuid
+import weakref
+
+
+ATTENTION_MEASURE_KEY = "attention_measure_v1"
+ATTENTION_MEASURE_CAPABILITIES_KEY = "attention_measure_capabilities_v1"
+PROVIDER_IDENTITY = "comfy.sol_h3.sm120"
+SPARSE_IMPLEMENTATION_PROFILE = "weighted_exact_blocks_v1"
+DENSE_IMPLEMENTATION_PROFILE = "dense_exact_v1"
+SPARSE_NUMERICAL_ROUTE = "sol_h3_sm120_weighted_exact_blocks"
+DENSE_NUMERICAL_ROUTE = "sol_h3_weighted_dense_exact"
+# Backwards-compatible names used by the first provider tests and callers.
+IMPLEMENTATION_PROFILE = SPARSE_IMPLEMENTATION_PROFILE
+NUMERICAL_ROUTE = SPARSE_NUMERICAL_ROUTE
+_ROUTE_PROFILES = {
+    SPARSE_NUMERICAL_ROUTE: SPARSE_IMPLEMENTATION_PROFILE,
+    DENSE_NUMERICAL_ROUTE: DENSE_IMPLEMENTATION_PROFILE,
+}
+_OWNER_GENERATIONS = {}
+_OWNER_GENERATIONS_LOCK = threading.Lock()
+
+
+def _core(required=True):
+    try:
+        return importlib.import_module("comfy.attention_measure")
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"comfy", "comfy.attention_measure"}:
+            raise
+        if required:
+            raise RuntimeError(
+                "attention_measure_v1 requires a ComfyUI build with the generic attention-measure contract"
+            ) from exc
+        return None
+
+
+def _provider_name(provider):
+    if provider is None:
+        return "comfy.default"
+    return f"{getattr(provider, '__module__', '<unknown>')}.{getattr(provider, '__qualname__', type(provider).__name__)}"
+
+
+def _stateless_function_identity(provider):
+    """Return a stable implementation identity for a genuinely stateless function.
+
+    Attention preprocess factories may create a fresh function object for every
+    model invocation. Object identity is not numerical identity in that case and
+    would grow the request-scoped weighted-plan cache once per evaluation. Only
+    functions with no closure/default state qualify for code identity; anything
+    stateful falls back to concrete owner-generation tracking below.
+    """
+    code = getattr(provider, "__code__", None)
+    if code is None:
+        return None
+    if getattr(provider, "__closure__", None) is not None:
+        return None
+    if getattr(provider, "__defaults__", None):
+        return None
+    if getattr(provider, "__kwdefaults__", None):
+        return None
+    digest = hashlib.sha256(marshal.dumps(code)).hexdigest()
+    return ("stateless_function_v1", _provider_name(provider), digest)
+
+
+def _owner_identity(provider):
+    if provider is None:
+        return ("singleton_v1", "comfy.default")
+    stable = _stateless_function_identity(provider)
+    if stable is not None:
+        return stable
+
+    # Stateful callable identity must not be represented by raw id(obj): the
+    # object may die while a digest remains in a request cache and CPython may
+    # later reuse that address for a different owner. A weakref-bound generation
+    # token changes on replacement without globally retaining the provider.
+    try:
+        weakref.ref(provider)
+    except TypeError as exc:
+        raise RuntimeError(
+            "stateful attention preprocessing/provider owners must support weak references"
+        ) from exc
+
+    key = id(provider)
+    with _OWNER_GENERATIONS_LOCK:
+        current = _OWNER_GENERATIONS.get(key)
+        if current is not None and current[0]() is provider:
+            token = current[1]
+        else:
+            token = uuid.uuid4().hex
+
+            def cleanup(ref, *, owner_id=key, generation=token):
+                with _OWNER_GENERATIONS_LOCK:
+                    retained = _OWNER_GENERATIONS.get(owner_id)
+                    if retained is not None and retained[0] is ref and retained[1] == generation:
+                        _OWNER_GENERATIONS.pop(owner_id, None)
+
+            _OWNER_GENERATIONS[key] = (weakref.ref(provider, cleanup), token)
+    return ("owner_generation_v1", _provider_name(provider), token)
+
+
+def preprocess_digest(provider):
+    """Hash numerical preprocessing semantics plus concrete stateful ownership.
+
+    Closure-free/default-free function preprocessors are identified by immutable
+    code so equivalent factory-created wrappers share one numerical identity.
+    Stateful callables retain concrete weakref-bound generations so replacement
+    cannot inherit a cached plan through CPython address reuse.
+    """
+    chain = []
+    seen = set()
+    current = provider
+    while hasattr(current, "attention_preprocess_v1"):
+        if id(current) in seen:
+            raise RuntimeError("cyclic attention preprocessing contract")
+        seen.add(id(current))
+        transform, current = current.attention_preprocess_v1
+        chain.append(_owner_identity(transform))
+    chain.append(_owner_identity(current))
+    return hashlib.sha256(repr(tuple(chain)).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ProviderOwner:
+    generation: str
+
+
+class Capability:
+    api = 1
+    operator = "key_log_measure"
+    provider_identity = PROVIDER_IDENTITY
+
+    def __init__(self, owner):
+        self.owner = owner
+
+    def prepare(self, request, execution_context):
+        core = _core()
+        if not isinstance(execution_context, core.MeasureExecutionContext):
+            raise TypeError("Sol-H3 attention measure requires MeasureExecutionContext")
+        if execution_context.owner is not self.owner:
+            raise RuntimeError("Sol-H3 attention-measure capability is bound to another owner")
+        if execution_context.provider_identity != PROVIDER_IDENTITY:
+            raise RuntimeError("Sol-H3 attention-measure provider identity changed during binding")
+        implementation_profile = _ROUTE_PROFILES.get(execution_context.numerical_route)
+        if implementation_profile is None:
+            raise RuntimeError("Sol-H3 attention-measure numerical route is not capability-bound")
+        return core.bind(
+            request,
+            context=execution_context,
+            block_size=64,
+            implementation_profile=implementation_profile,
+        )
+
+
+def register(transformer_options, *, refresh_owned=False):
+    """Register a model-local capability when the companion core API exists.
+
+    ``MODEL.clone()`` can carry a shallow copy of the previous capability
+    registry. A new Sol-H3 installation owns a new replacement chain, so it must
+    receive a fresh owner generation rather than silently reusing the source
+    model's capability. Only a capability created by this module may be
+    refreshed; another owner under the same provider identity remains an error.
+    """
+    core = _core(required=False)
+    if core is None:
+        return None
+    current = transformer_options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+    existing = current.get(PROVIDER_IDENTITY) if isinstance(current, dict) else None
+    if existing is not None:
+        if not isinstance(existing, Capability):
+            raise RuntimeError("attention-measure provider identity is already owned by another capability")
+        if not refresh_owned:
+            return existing
+        registry = dict(current)
+        del registry[PROVIDER_IDENTITY]
+        transformer_options[ATTENTION_MEASURE_CAPABILITIES_KEY] = registry
+    capability = Capability(ProviderOwner(f"sol-h3-{uuid.uuid4().hex}"))
+    core.register_capability(transformer_options, PROVIDER_IDENTITY, capability)
+    return capability
+
+
+def prepare(
+    state,
+    transformer_options,
+    request,
+    *,
+    block_index,
+    layout,
+    q_rows,
+    kv_rows,
+    dtype,
+    device,
+    head_dim,
+    existing_sink,
+    external_sequence,
+    preprocess_identity,
+    implementation_profile=SPARSE_IMPLEMENTATION_PROFILE,
+    numerical_route=SPARSE_NUMERICAL_ROUTE,
+):
+    """Bind one actual all-row weighted route and cache its O(T) bias per request."""
+    core = _core()
+    expected_profile = _ROUTE_PROFILES.get(numerical_route)
+    if expected_profile is None or expected_profile != implementation_profile:
+        raise ValueError("Sol-H3 attention-measure route/profile pair is invalid")
+    registry = transformer_options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+    capability = registry.get(PROVIDER_IDENTITY) if isinstance(registry, dict) else None
+    if not isinstance(capability, Capability):
+        raise RuntimeError(
+            "attention_measure_v1 selected Sol-H3 but its owner-bound capability is not registered"
+        )
+    digest = core.semantic_digest(request)
+    context = core.MeasureExecutionContext(
+        provider_identity=PROVIDER_IDENTITY,
+        block_index=int(block_index),
+        owner=capability.owner,
+        owner_generation=capability.owner.generation,
+        layout=layout,
+        q_rows=int(q_rows),
+        kv_rows=int(kv_rows),
+        dtype=dtype,
+        device=device,
+        head_dim=int(head_dim),
+        mask_class="none",
+        preprocess_digest=str(preprocess_identity),
+        numerical_route=numerical_route,
+        existing_sink=tuple(existing_sink),
+        external_sequence=external_sequence,
+    )
+    key = (
+        digest,
+        context.block_index,
+        context.q_rows,
+        context.kv_rows,
+        str(context.device),
+        str(context.dtype),
+        context.head_dim,
+        context.existing_sink,
+        context.preprocess_digest,
+        context.owner_generation,
+        implementation_profile,
+        numerical_route,
+    )
+    plan = state.measure_plans.get(key)
+    if plan is None:
+        plan = core.prepare_capability(transformer_options, request, context)
+        if plan.implementation_profile != implementation_profile or plan.numerical_route != numerical_route:
+            raise RuntimeError("Sol-H3 capability selected an unexpected attention-measure route/profile")
+        bias_key = (digest, str(context.device))
+        shared = state.measure_biases.get(bias_key)
+        if shared is None:
+            state.measure_biases[bias_key] = plan.key_log_measure
+        elif shared is not plan.key_log_measure:
+            plan = replace(plan, key_log_measure=shared)
+        state.measure_plans[key] = plan
+    else:
+        # The plan cache intentionally excludes transient layout/external objects
+        # so identical geometry can reuse the O(T) measure buffer. Revalidate the
+        # current objects on every cache hit; otherwise a stale/foreign VDN
+        # external-sequence contract or changed H3 layout could bypass core's
+        # fail-closed geometry checks merely because the semantic request digest
+        # and numerical route stayed the same.
+        core.validate_h3(
+            request,
+            layout=context.layout,
+            q_rows=context.q_rows,
+            kv_rows=context.kv_rows,
+            external_sequence=context.external_sequence,
+        )
+        exact_k_block_range = core.merge_exact_k_blocks(
+            request,
+            64,
+            context.existing_sink,
+        )
+        if exact_k_block_range != plan.exact_k_block_range:
+            raise RuntimeError("cached Sol-H3 attention-measure exact K range is stale")
+    return plan
+
+
+def dense(q, k, v, heads, plan, *, scale=None, output_heads=False):
+    """Exact all-row weighted fallback over already-preprocessed BHND tensors."""
+    core = _core()
+    return core.weighted_dense(
+        q,
+        k,
+        v,
+        heads,
+        key_bias=plan.key_log_measure,
+        skip_reshape=True,
+        skip_output_reshape=bool(output_heads),
+        scale=scale,
+    )
+
+
+def receipt_fields(plan, *, call_token):
+    return (
+        ATTENTION_MEASURE_KEY,
+        ("sol_h3_evaluation", int(call_token)),
+        plan.owner_generation,
+        plan.semantic_digest,
+        plan.implementation_profile,
+        plan.numerical_route,
+        plan.q_rows,
+        plan.kv_rows,
+        plan.exact_range_digest,
+        plan.preprocess_digest,
+        True,
+    )

--- a/tests/test_flow_weighted_measure_contract.py
+++ b/tests/test_flow_weighted_measure_contract.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import math
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sol_h3 import weighted_measure
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("COMFYUI_PATH") or not os.environ.get("FLOW_PATH"),
+    reason="set COMFYUI_PATH and FLOW_PATH for real weighted Flow/Core contracts",
+)
+
+
+def _activate_real_sources():
+    for path in (os.environ["COMFYUI_PATH"], os.environ["FLOW_PATH"]):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+    import comfy.cli_args
+
+    comfy.cli_args.args.cpu = True
+
+
+def test_real_flow_weighted_request_binds_current_core_and_sol_provider():
+    _activate_real_sources()
+
+    from comfy import attention_measure as core
+    from h3_flow_regenerate.attention_measure import attention_measure_semantic_digest
+    from h3_flow_regenerate.mixed_grid import (
+        MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+        MixedGridPlan,
+        mixed_attention_measure_contract,
+    )
+
+    flow_plan = MixedGridPlan(
+        prefix=torch.empty(1, 24, 1, 16, 32),
+        temporal=2,
+        source_h=16,
+        source_w=16,
+        measure_profile=MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+    )
+    request = mixed_attention_measure_contract(
+        flow_plan,
+        video_start=10,
+        sequence_rows=202,
+    )
+    assert request is not None
+    assert request["operator"] == "key_log_measure"
+    assert request["q_rows"] == request["kv_rows"] == 202
+    assert request["source_grid"] == [8, 8]
+    assert request["prefix_grid"] == [8, 16]
+    assert core.normalize(request) == request
+
+    layout = SimpleNamespace(
+        seq_len=202,
+        segments=((0, 10, "text"), (10, 202, "video")),
+    )
+    external = {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 138,
+        "sequence_rows": 202,
+        "video_start": 10,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 64,
+        "prefix_rows_per_frame": 128,
+    }
+    options = {}
+    capability = weighted_measure.register(options, refresh_owned=True)
+    assert capability is not None
+    state = SimpleNamespace(measure_plans={}, measure_biases={})
+
+    bound = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        block_index=3,
+        layout=layout,
+        q_rows=202,
+        kv_rows=202,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        head_dim=128,
+        existing_sink=(0, 1),
+        external_sequence=external,
+        preprocess_identity="real-flow-core-sol-v1",
+    )
+
+    digest = attention_measure_semantic_digest(request)
+    assert digest == core.semantic_digest(request) == bound.semantic_digest
+    assert bound.provider_identity == weighted_measure.PROVIDER_IDENTITY
+    assert bound.owner_generation == capability.owner.generation
+    assert bound.implementation_profile == weighted_measure.SPARSE_IMPLEMENTATION_PROFILE
+    assert bound.numerical_route == weighted_measure.SPARSE_NUMERICAL_ROUTE
+    assert bound.exact_k_block_range == (0, 3)
+    assert bound.key_log_measure.shape == (202,)
+    assert bound.key_log_measure.dtype == torch.float32
+    assert bound.key_log_measure.is_contiguous()
+
+    expected = torch.zeros(202, dtype=torch.float32)
+    expected[10:138] = math.log(0.5)
+    assert torch.equal(bound.key_log_measure, expected)
+    assert torch.exp(bound.key_log_measure[10:138]).sum().item() == 64.0
+    assert torch.exp(bound.key_log_measure[138:202]).sum().item() == 64.0

--- a/tests/test_rectangular.py
+++ b/tests/test_rectangular.py
@@ -77,8 +77,8 @@ def test_cute_host_output_lse_sink_and_compile_cache(monkeypatch):
         prepares.append((q.shape[1], k.shape[1], kw))
         kc = torch.empty(1, (k.shape[1] + 63)//64, 2, 128)
         return kc, kc, torch.empty(1, (q.shape[1] + 63)//64, 2)
-    def compile_(key, tensors, scale, start, end, stream):
-        compiles.append((key, [t.shape for t in tensors], start, end))
+    def compile_(key, tensors, scale, start, end, stream, key_bias_enabled):
+        compiles.append((key, [t.shape for t in tensors], start, end, key_bias_enabled))
         def compiled(*args, **kwargs):
             args[3].copy_(args[0])
         interface._compiled[key] = compiled
@@ -93,9 +93,10 @@ def test_cute_host_output_lse_sink_and_compile_cache(monkeypatch):
                     valid_tokens=tq)
         assert got.shape == q.shape
     assert len(compiles) == 3
-    for _, shapes, start, end in compiles:
+    for _, shapes, start, end, key_bias_enabled in compiles:
         assert shapes[3] == shapes[0]
-        assert shapes[7] == shapes[0][:3]  # LSE: [B,Tq,H]
+        assert shapes[8] == shapes[0][:3]  # LSE: [B,Tq,H]
+        assert key_bias_enabled is False
         assert start == 0 and end == (shapes[1][1] + 63)//64
     assert all(kw['valid_tokens'] == tq and kw['valid_kv_tokens'] == tk
                for tq, tk, kw in prepares)

--- a/tests/test_sana_contract.py
+++ b/tests/test_sana_contract.py
@@ -54,7 +54,7 @@ def test_manifest_names_are_platform_independent():
 def test_public_api():
     assert tuple(inspect.signature(interface.sol_attn).parameters) == (
         'q', 'k', 'v', 'scale', 'tau', 'thresh_type', 'kv_splits',
-        'sink_tokens', 'sink_start', 'compile_bucket_size')
+        'sink_tokens', 'sink_start', 'compile_bucket_size', 'key_bias')
     assert interface._backend_for_arch((12, 0), cute_available=True) == 'cute_sm120'
     assert interface._backend_for_arch((12, 0), cute_available=False) == 'triton'
     assert interface._backend_for_arch((10, 3), cute_available=True) == 'cute_sm100'
@@ -177,3 +177,27 @@ def test_missing_cute_counts_no_sparse_and_caches_reason(monkeypatch):
     assert len(attempts) == 1
     assert state.sparse_calls == 0
     assert state.kernel is None
+
+
+
+def test_weighted_public_api_is_sm120_only_and_validates_bias(monkeypatch):
+    q = torch.zeros(1, 65, 2, 128, dtype=torch.bfloat16)
+    monkeypatch.setattr(interface, '_validate_inputs', lambda *a, **k: (10, 0))
+    monkeypatch.setattr(interface, '_cute_runtime_available', lambda: True)
+    with pytest.raises(ValueError, match='cute_sm120 only'):
+        interface.sol_attn(q, q, q, key_bias=torch.zeros(65))
+
+    monkeypatch.setattr(interface, '_validate_inputs', lambda *a, **k: (12, 0))
+    with pytest.raises(ValueError, match='one natural-log value'):
+        interface.sol_attn(q, q, q, key_bias=torch.zeros(64))
+    with pytest.raises(ValueError, match='finite positive'):
+        interface.sol_attn(q, q, q, scale=0.0, key_bias=torch.zeros(65))
+
+
+def test_sm120_source_injects_bias_only_between_exact_mask_and_softmax():
+    source = (Path(interface.__file__).parent / 'sm120' / 'mainloop.py').read_text()
+    exact = source.index('mask_exact_scores(tSrS, tScS, block_len, q_len)')
+    inject = source.index('add_exact_key_bias(', exact)
+    softmax = source.index('row_scale = online_softmax(', inject)
+    assert exact < inject < softmax
+    assert 'key_bias[absolute_col]' in source

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -24,8 +24,7 @@ def test_sink_geometry_rejects_nonprefix_and_out_of_range():
     assert sparse._sink_blocks(0, 0, 130) == [0, 0]
     assert sparse._sink_blocks(0, 64, 130) == [0, 1]
     assert sparse._sink_blocks(0, 65, 130) == [0, 2]
-    with pytest.raises(RuntimeError, match="beginning at row zero"):
-        sparse._sink_blocks(64, 64, 130)
+    assert sparse._sink_blocks(64, 64, 130) == [1, 2]
     with pytest.raises(RuntimeError, match="outside"):
         sparse._sink_blocks(0, 131, 130)
 
@@ -147,3 +146,61 @@ def test_failed_arithmetic_never_counts_sparse(monkeypatch):
     with pytest.raises(RuntimeError, match="arithmetic gate failed"):
         sparse.attention(q, q, q, 1, state.config, state)
     assert state.sparse_calls == 0
+
+
+
+def test_weighted_bridge_uses_measure_specific_gate_and_exact_k_range(monkeypatch):
+    calls = []
+
+    def kernel(q, k, v, **kw):
+        calls.append(kw)
+        bias = kw.get("key_bias")
+        mask = None if bias is None else bias.view(1, 1, 1, -1)
+        return F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), attn_mask=mask
+        ).transpose(1, 2)
+
+    monkeypatch.setattr(sparse, "load_kernel", lambda device: kernel)
+    q, k, v = (torch.randn(1, 2, 260, 128).to(torch.bfloat16) for _ in range(3))
+    bias = torch.zeros(260, dtype=torch.float32)
+    bias[64:192] = torch.log(torch.tensor(0.5))
+    state = Request(Config(exact=False, backend="sol"))
+    out = sparse.attention(
+        q, k, v, 5, state.config, state,
+        key_bias=bias,
+        exact_k_blocks=(0, 3),
+        calibration_identity="measure-a",
+    )
+    assert out.shape == (1, 260, 256)
+    assert [c["sink_tokens"] for c in calls] == [260, 192]
+    assert all(c["sink_start"] == 0 for c in calls)
+    assert all(c["key_bias"] is bias for c in calls)
+    assert len(state.gates) == 1
+
+    sparse.attention(
+        q, k, v, 5, state.config, state,
+        key_bias=bias,
+        exact_k_blocks=(0, 3),
+        calibration_identity="measure-a",
+    )
+    assert len(calls) == 3
+    assert len(state.gates) == 1
+
+    other = bias.clone()
+    other[64:192] = torch.log(torch.tensor(0.25))
+    sparse.attention(
+        q, k, v, 5, state.config, state,
+        key_bias=other,
+        exact_k_blocks=(0, 3),
+        calibration_identity="measure-b",
+    )
+    assert len(calls) == 5
+    assert len(state.gates) == 2
+
+
+def test_weighted_bridge_rejects_bias_without_bound_route_metadata(monkeypatch):
+    monkeypatch.setattr(sparse, "load_kernel", lambda device: None)
+    q = torch.ones(1, 1, 65, 128, dtype=torch.bfloat16)
+    state = Request(Config(exact=False, backend="sol"))
+    with pytest.raises(RuntimeError, match="calibration identity"):
+        sparse.attention(q, q, q, 1, state.config, state, key_bias=torch.zeros(65))

--- a/tests/test_weighted_bias_dtype.py
+++ b/tests/test_weighted_bias_dtype.py
@@ -1,0 +1,27 @@
+import torch
+
+from sol_h3 import sparse
+
+
+def test_dense_reference_casts_fp32_weighted_bias_to_query_dtype(monkeypatch):
+    seen = {}
+
+    def fake_sdpa(q, k, v, *, attn_mask=None, **kwargs):
+        seen["query_dtype"] = q.dtype
+        seen["bias_dtype"] = None if attn_mask is None else attn_mask.dtype
+        assert attn_mask is not None
+        assert attn_mask.dtype == q.dtype
+        assert attn_mask.shape == (1, 1, 1, k.shape[2])
+        return torch.zeros_like(q)
+
+    monkeypatch.setattr(sparse.F, "scaled_dot_product_attention", fake_sdpa)
+    q = torch.zeros(1, 2, 3, 128, dtype=torch.bfloat16)
+    k = torch.zeros(1, 2, 5, 128, dtype=torch.bfloat16)
+    v = torch.zeros_like(k)
+    key_bias = torch.linspace(-1.0, 0.0, 5, dtype=torch.float32)
+
+    out = sparse._dense_reference(q, k, v, None, key_bias=key_bias)
+
+    assert seen == {"query_dtype": torch.bfloat16, "bias_dtype": torch.bfloat16}
+    assert out.shape == (1, 3, 2, 128)
+    assert key_bias.dtype == torch.float32

--- a/tests/test_weighted_history_receipts.py
+++ b/tests/test_weighted_history_receipts.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+from sol_h3 import interop, weighted_measure
+
+
+def _plan(profile, route):
+    return SimpleNamespace(
+        owner_generation="owner-generation",
+        semantic_digest="semantic-digest",
+        implementation_profile=profile,
+        numerical_route=route,
+        q_rows=44958,
+        kv_rows=44958,
+        exact_range_digest="exact-range-digest",
+        preprocess_digest="preprocess-digest",
+    )
+
+
+def _weighted_receipt(route, profile, numerical_route):
+    plan = _plan(profile, numerical_route)
+    return (
+        "sol_h3",
+        0,
+        route,
+        weighted_measure.receipt_fields(plan, call_token=1),
+    )
+
+
+def test_history_policy_accepts_completed_weighted_dense_and_sparse_receipts():
+    policy = interop.HistoryPolicy(SimpleNamespace())
+    dense = _weighted_receipt(
+        "dense_warmup",
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    sparse = _weighted_receipt(
+        "sol_external_mixed_weighted_measure",
+        weighted_measure.SPARSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.SPARSE_NUMERICAL_ROUTE,
+    )
+    fallback = _weighted_receipt(
+        "kernel_unavailable:test",
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    assert policy.accept_receipts((dense, sparse, fallback))
+
+
+def test_history_policy_rejects_weighted_route_profile_mismatch_and_malformed_token():
+    policy = interop.HistoryPolicy(SimpleNamespace())
+    wrong_route = _weighted_receipt(
+        "sol_external_mixed_weighted_measure",
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    assert not policy.accept_receipts((wrong_route,))
+
+    good = _weighted_receipt(
+        "dense_warmup",
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    fields = list(good[3])
+    fields[1] = ("sol_h3_evaluation", True)
+    malformed = (*good[:3], tuple(fields))
+    assert not policy.accept_receipts((malformed,))
+
+
+def test_history_policy_keeps_legacy_three_field_receipts():
+    policy = interop.HistoryPolicy(SimpleNamespace())
+    assert policy.accept_receipts((("sol_h3", 0, "dense_warmup"),))
+    assert not policy.accept_receipts((("sol_h3", 0, "unknown"),))

--- a/tests/test_weighted_measure.py
+++ b/tests/test_weighted_measure.py
@@ -1,0 +1,210 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sol_h3 import weighted_measure
+
+
+def test_register_refreshes_only_its_own_model_local_capability(monkeypatch):
+    class Core:
+        @staticmethod
+        def register_capability(options, provider_identity, capability):
+            registry = dict(options.get(weighted_measure.ATTENTION_MEASURE_CAPABILITIES_KEY, {}))
+            existing = registry.get(provider_identity)
+            if existing is not None and existing is not capability:
+                raise RuntimeError("duplicate provider")
+            registry[provider_identity] = capability
+            options[weighted_measure.ATTENTION_MEASURE_CAPABILITIES_KEY] = registry
+
+    monkeypatch.setattr(weighted_measure, "_core", lambda required=True: Core)
+    source = {}
+    first = weighted_measure.register(source)
+    source_registry = source[weighted_measure.ATTENTION_MEASURE_CAPABILITIES_KEY]
+
+    # Reproduce MODEL.clone() carrying the source model's nested registry by
+    # reference. Refreshing the clone must not mutate or reuse the source owner.
+    clone = {weighted_measure.ATTENTION_MEASURE_CAPABILITIES_KEY: source_registry}
+    second = weighted_measure.register(clone, refresh_owned=True)
+
+    assert second is not first
+    assert second.owner is not first.owner
+    assert second.owner.generation != first.owner.generation
+    assert source_registry[weighted_measure.PROVIDER_IDENTITY] is first
+    assert clone[weighted_measure.ATTENTION_MEASURE_CAPABILITIES_KEY][weighted_measure.PROVIDER_IDENTITY] is second
+
+
+def test_register_rejects_foreign_provider_identity_owner(monkeypatch):
+    class Core:
+        register_capability = staticmethod(lambda *args, **kwargs: None)
+
+    monkeypatch.setattr(weighted_measure, "_core", lambda required=True: Core)
+    options = {
+        weighted_measure.ATTENTION_MEASURE_CAPABILITIES_KEY: {
+            weighted_measure.PROVIDER_IDENTITY: object(),
+        }
+    }
+    with pytest.raises(RuntimeError, match="another capability"):
+        weighted_measure.register(options, refresh_owned=True)
+
+
+def test_preprocess_digest_tracks_numerical_chain_and_concrete_stateful_owners():
+    class Leaf:
+        pass
+
+    def transform_a(q, k, v, heads, **kw):
+        return q, k, v
+
+    def transform_b(q, k, v, heads, **kw):
+        return q, k, v
+
+    leaf_a = Leaf()
+    leaf_b = Leaf()
+    provider_a = SimpleNamespace(attention_preprocess_v1=(transform_a, leaf_a))
+    provider_b = SimpleNamespace(attention_preprocess_v1=(transform_a, leaf_b))
+    provider_c = SimpleNamespace(attention_preprocess_v1=(transform_b, leaf_a))
+
+    digest = weighted_measure.preprocess_digest(provider_a)
+    assert digest == weighted_measure.preprocess_digest(provider_a)
+    assert digest != weighted_measure.preprocess_digest(provider_b)
+    assert digest != weighted_measure.preprocess_digest(provider_c)
+
+
+def test_preprocess_digest_stabilizes_factory_recreated_stateless_functions():
+    class Leaf:
+        pass
+
+    leaf = Leaf()
+
+    def factory():
+        # Mirrors the reviewed Untwist H3 preprocessing shape: the wrapper
+        # function is recreated per model invocation, but the preprocessor itself
+        # carries no closure/default state and reads execution state from kwargs.
+        def preprocess(q, k, v, heads, **kwargs):
+            options = kwargs.get("transformer_options")
+            return q, k, v if options is not None else v
+
+        return SimpleNamespace(attention_preprocess_v1=(preprocess, leaf))
+
+    first = factory()
+    second = factory()
+    assert first.attention_preprocess_v1[0] is not second.attention_preprocess_v1[0]
+    assert first.attention_preprocess_v1[0].__closure__ is None
+    assert weighted_measure.preprocess_digest(first) == weighted_measure.preprocess_digest(second)
+
+
+def test_preprocess_digest_keeps_stateful_recreated_functions_owner_bound():
+    class Leaf:
+        pass
+
+    leaf = Leaf()
+
+    def factory(scale):
+        def preprocess(q, k, v, heads, **kwargs):
+            return q, k * scale, v
+
+        return SimpleNamespace(attention_preprocess_v1=(preprocess, leaf))
+
+    first = factory(0.5)
+    second = factory(0.5)
+    assert first.attention_preprocess_v1[0].__closure__ is not None
+    assert weighted_measure.preprocess_digest(first) != weighted_measure.preprocess_digest(second)
+
+
+def test_preprocess_digest_rejects_unsafe_nonweakrefable_stateful_owner_and_cycles():
+    def transform(q, k, v, heads, **kw):
+        return q, k, v
+
+    with pytest.raises(RuntimeError, match="weak references"):
+        weighted_measure.preprocess_digest(SimpleNamespace(attention_preprocess_v1=(transform, object())))
+
+    cycle = SimpleNamespace()
+    cycle.attention_preprocess_v1 = (transform, cycle)
+    with pytest.raises(RuntimeError, match="cyclic"):
+        weighted_measure.preprocess_digest(cycle)
+
+
+def test_provider_binds_real_core_measure_contract_when_available():
+    core = pytest.importorskip("comfy.attention_measure")
+
+    options = {}
+    capability = weighted_measure.register(options, refresh_owned=True)
+    assert capability is not None
+
+    rows = 202
+    layout = SimpleNamespace(seq_len=rows, segments=((0, 10, "text"), (10, rows, "video")))
+    external = {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 138,
+        "sequence_rows": rows,
+        "video_start": 10,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 64,
+        "prefix_rows_per_frame": 128,
+    }
+    request = {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+        "q_rows": rows,
+        "kv_rows": rows,
+        "video_start": 10,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_grid": [8, 8],
+        "prefix_grid": [8, 16],
+        "segments": [
+            {"start": 0, "stop": 10, "mass_num": 1, "mass_den": 1},
+            {"start": 10, "stop": 138, "mass_num": 1, "mass_den": 2},
+            {"start": 138, "stop": rows, "mass_num": 1, "mass_den": 1},
+        ],
+    }
+    state = SimpleNamespace(measure_plans={}, measure_biases={})
+    plan = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        block_index=0,
+        layout=layout,
+        q_rows=rows,
+        kv_rows=rows,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        head_dim=128,
+        existing_sink=(0, 1),
+        external_sequence=external,
+        preprocess_identity="test-preprocess",
+    )
+
+    assert plan.provider_identity == weighted_measure.PROVIDER_IDENTITY
+    assert plan.owner_generation == capability.owner.generation
+    assert plan.implementation_profile == weighted_measure.IMPLEMENTATION_PROFILE
+    assert plan.exact_k_block_range == (0, 3)
+    assert plan.key_log_measure.dtype == torch.float32
+    assert plan.key_log_measure.is_contiguous()
+    assert torch.count_nonzero(plan.key_log_measure[:10]) == 0
+    assert torch.allclose(plan.key_log_measure[10:138], torch.full((128,), torch.log(torch.tensor(0.5))))
+    assert torch.count_nonzero(plan.key_log_measure[138:]) == 0
+
+    cached = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        block_index=0,
+        layout=layout,
+        q_rows=rows,
+        kv_rows=rows,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        head_dim=128,
+        existing_sink=(0, 1),
+        external_sequence=external,
+        preprocess_identity="test-preprocess",
+    )
+    assert cached is plan
+    assert state.measure_biases[(core.semantic_digest(request), "cpu")] is plan.key_log_measure

--- a/tests/test_weighted_measure_routes.py
+++ b/tests/test_weighted_measure_routes.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sol_h3 import weighted_measure
+
+
+core = pytest.importorskip("comfy.attention_measure")
+
+
+def _fixture():
+    rows = 202
+    layout = SimpleNamespace(seq_len=rows, segments=((0, 10, "text"), (10, rows, "video")))
+    request = {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+        "q_rows": rows,
+        "kv_rows": rows,
+        "video_start": 10,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_grid": [8, 8],
+        "prefix_grid": [8, 16],
+        "segments": [
+            {"start": 0, "stop": 10, "mass_num": 1, "mass_den": 1},
+            {"start": 10, "stop": 138, "mass_num": 1, "mass_den": 2},
+            {"start": 138, "stop": rows, "mass_num": 1, "mass_den": 1},
+        ],
+    }
+    common = dict(
+        block_index=3,
+        layout=layout,
+        q_rows=rows,
+        kv_rows=rows,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        head_dim=128,
+        existing_sink=(0, 1),
+        external_sequence=None,
+        preprocess_identity="route-profile-test",
+    )
+    return rows, request, common
+
+
+def _external_sequence():
+    return {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 138,
+        "sequence_rows": 202,
+        "video_start": 10,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 64,
+        "prefix_rows_per_frame": 128,
+    }
+
+
+def test_dense_and_sparse_routes_bind_distinct_plans_but_share_measure_buffer():
+    rows, request, common = _fixture()
+    options = {}
+    weighted_measure.register(options, refresh_owned=True)
+    state = SimpleNamespace(measure_plans={}, measure_biases={})
+
+    sparse_plan = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        **common,
+        implementation_profile=weighted_measure.SPARSE_IMPLEMENTATION_PROFILE,
+        numerical_route=weighted_measure.SPARSE_NUMERICAL_ROUTE,
+    )
+    dense_plan = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        **common,
+        implementation_profile=weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        numerical_route=weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+
+    assert sparse_plan is not dense_plan
+    assert sparse_plan.implementation_profile == "weighted_exact_blocks_v1"
+    assert dense_plan.implementation_profile == "dense_exact_v1"
+    assert sparse_plan.numerical_route == weighted_measure.SPARSE_NUMERICAL_ROUTE
+    assert dense_plan.numerical_route == weighted_measure.DENSE_NUMERICAL_ROUTE
+    assert sparse_plan.exact_k_block_range == dense_plan.exact_k_block_range == (0, 3)
+    assert sparse_plan.key_log_measure is dense_plan.key_log_measure
+    assert sparse_plan.key_log_measure.shape == (rows,)
+    assert len(state.measure_plans) == 2
+    assert len(state.measure_biases) == 1
+
+
+def test_cached_plan_revalidates_current_layout_external_sequence_and_sink():
+    _, request, common = _fixture()
+    options = {}
+    weighted_measure.register(options, refresh_owned=True)
+    state = SimpleNamespace(measure_plans={}, measure_biases={})
+    external = _external_sequence()
+
+    first = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        **{**common, "external_sequence": external},
+    )
+    second = weighted_measure.prepare(
+        state,
+        options,
+        request,
+        **{**common, "external_sequence": dict(external)},
+    )
+    assert second is first
+    assert len(state.measure_plans) == 1
+    assert len(state.measure_biases) == 1
+
+    stale_external = dict(external)
+    stale_external["prefix_rows_per_frame"] = 64
+    with pytest.raises(ValueError, match="external-sequence"):
+        weighted_measure.prepare(
+            state,
+            options,
+            request,
+            **{**common, "external_sequence": stale_external},
+        )
+
+    stale_layout = SimpleNamespace(
+        seq_len=202,
+        segments=((0, 11, "text"), (11, 202, "video")),
+    )
+    with pytest.raises(ValueError, match="layout"):
+        weighted_measure.prepare(
+            state,
+            options,
+            request,
+            **{**common, "layout": stale_layout, "external_sequence": external},
+        )
+
+    # Python bools alias 0/1 in tuple hashes/equality. Without explicit core
+    # revalidation this malformed sink can hit the plan cached under (0, 1).
+    with pytest.raises(ValueError, match="existing sink range"):
+        weighted_measure.prepare(
+            state,
+            options,
+            request,
+            **{**common, "existing_sink": (False, 1), "external_sequence": external},
+        )
+
+    assert len(state.measure_plans) == 1
+    assert len(state.measure_biases) == 1
+
+
+def test_invalid_route_profile_pair_fails_before_capability_dispatch():
+    _, request, common = _fixture()
+    options = {}
+    weighted_measure.register(options, refresh_owned=True)
+    state = SimpleNamespace(measure_plans={}, measure_biases={})
+
+    with pytest.raises(ValueError, match="route/profile pair"):
+        weighted_measure.prepare(
+            state,
+            options,
+            request,
+            **common,
+            implementation_profile=weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+            numerical_route=weighted_measure.SPARSE_NUMERICAL_ROUTE,
+        )
+    assert not state.measure_plans
+    assert not state.measure_biases

--- a/tests/test_weighted_runtime.py
+++ b/tests/test_weighted_runtime.py
@@ -1,0 +1,262 @@
+from types import SimpleNamespace
+
+import torch
+
+from sol_h3 import runtime, sparse, weighted_measure
+from sol_h3.contracts import Config
+from sol_h3.runtime import BlockPatch, Request, _FORWARD
+
+
+ROWS = 202
+HEADS = 2
+DIM = 128
+
+
+def _contracts():
+    layout = SimpleNamespace(
+        seq_len=ROWS,
+        segments=((0, 10, "text"), (10, ROWS, "video")),
+    )
+    external = {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 138,
+        "sequence_rows": ROWS,
+        "video_start": 10,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 64,
+        "prefix_rows_per_frame": 128,
+    }
+    measure = {"api": 1, "operator": "key_log_measure"}
+    return layout, external, measure
+
+
+def _plan(profile, route):
+    return SimpleNamespace(
+        key_log_measure=torch.zeros(ROWS, dtype=torch.float32),
+        exact_k_block_range=(0, 3),
+        semantic_digest="measure-digest",
+        owner_generation="owner-generation",
+        implementation_profile=profile,
+        numerical_route=route,
+        q_rows=ROWS,
+        kv_rows=ROWS,
+        exact_range_digest="exact-range-digest",
+        preprocess_digest="preprocess-digest",
+    )
+
+
+def _run_block(monkeypatch, cfg, *, sparse_impl, dense_impl, include_external=True):
+    state = Request(cfg)
+    layout, external, measure = _contracts()
+    q, k, v = (
+        torch.randn(1, HEADS, ROWS, DIM, dtype=torch.bfloat16)
+        for _ in range(3)
+    )
+
+    monkeypatch.setattr(runtime, "_shape_reason", lambda *args, **kwargs: None)
+    monkeypatch.setattr(weighted_measure, "preprocess_digest", lambda provider: "preprocess-digest")
+
+    prepare_calls = []
+    plans = []
+
+    def prepare(state_arg, options, request, **kwargs):
+        prepare_calls.append((state_arg, options, request, kwargs))
+        assert kwargs["q_rows"] == ROWS
+        assert kwargs["kv_rows"] == ROWS
+        assert kwargs["existing_sink"] == (0, 1)
+        assert kwargs["preprocess_identity"] == "preprocess-digest"
+        profile = kwargs["implementation_profile"]
+        route = kwargs["numerical_route"]
+        plan = _plan(profile, route)
+        plans.append(plan)
+        return plan
+
+    monkeypatch.setattr(weighted_measure, "prepare", prepare)
+    monkeypatch.setattr(weighted_measure, "dense", dense_impl)
+    monkeypatch.setattr(sparse, "attention", sparse_impl)
+    monkeypatch.setattr(
+        runtime,
+        "reduce_kv",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("weighted route must never enter legacy K/V reduction")
+        ),
+    )
+
+    model = SimpleNamespace(blocks=[SimpleNamespace(attn=SimpleNamespace(forward=None))])
+    token = _FORWARD.set((model, state, 0, set(), []))
+
+    def original_block(call_args):
+        options = call_args["transformer_options"]
+        override = options["optimized_attention_override"]
+        return override(
+            None,
+            q,
+            k,
+            v,
+            HEADS,
+            mask=None,
+            skip_reshape=True,
+            skip_output_reshape=False,
+            transformer_options=options,
+        )
+
+    receipts = []
+    options = {
+        "minimax_h3_layout": layout,
+        weighted_measure.ATTENTION_MEASURE_KEY: measure,
+        "attention_backend_receipts_v1": receipts,
+    }
+    if include_external:
+        options["vdn_h3_external_sequence_v1"] = external
+    try:
+        result = BlockPatch(0, cfg)(
+            {"transformer_options": options, "layout": layout},
+            {"original_block": original_block},
+        )
+    finally:
+        _FORWARD.reset(token)
+
+    return result, state, plans, prepare_calls, receipts
+
+
+def test_weighted_runtime_keeps_all_kv_rows_and_separates_q_prefix_from_k_sink(monkeypatch):
+    calls = []
+
+    def sparse_impl(q, k, v, prefix, config, state, **kwargs):
+        calls.append((q.shape, k.shape, v.shape, prefix, kwargs))
+        assert prefix == 10
+        assert k.shape[2] == v.shape[2] == ROWS
+        assert kwargs["key_bias"].shape == (ROWS,)
+        assert kwargs["exact_k_blocks"] == (0, 3)
+        assert kwargs["calibration_identity"] == "measure-digest"
+        assert kwargs["dense_attention"] is not None
+        state.sparse_calls += 1
+        return torch.zeros(1, ROWS, HEADS * DIM, dtype=q.dtype)
+
+    def dense_impl(*args, **kwargs):
+        raise AssertionError("hot weighted sparse route must not take dense fallback")
+
+    result, state, plans, _, receipts = _run_block(
+        monkeypatch,
+        Config(exact=False, backend="sol", dense_evaluations=0, dense_layers=0),
+        sparse_impl=sparse_impl,
+        dense_impl=dense_impl,
+    )
+
+    assert result.shape == (1, ROWS, HEADS * DIM)
+    assert len(calls) == 1
+    assert [(p.implementation_profile, p.numerical_route) for p in plans] == [(
+        weighted_measure.SPARSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.SPARSE_NUMERICAL_ROUTE,
+    )]
+    assert receipts[0][3][4:6] == (
+        weighted_measure.SPARSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.SPARSE_NUMERICAL_ROUTE,
+    )
+    assert state.external_mixed_weighted_measure_calls == 1
+    assert state.external_mixed_weighted_measure_q_rows == ROWS
+    assert state.external_mixed_weighted_measure_kv_rows == ROWS
+    assert state.external_mixed_measure_calls == 0
+
+
+def test_weighted_dense_warmup_preserves_all_rows_and_binds_dense_receipt(monkeypatch):
+    dense_calls = []
+
+    def sparse_impl(*args, **kwargs):
+        raise AssertionError("dense warmup must not dispatch sparse attention")
+
+    def dense_impl(q, k, v, heads, plan, *, scale=None, output_heads=False):
+        dense_calls.append((q.shape, k.shape, v.shape, heads, plan, scale, output_heads))
+        assert k.shape[2] == v.shape[2] == ROWS
+        assert plan.key_log_measure.shape == (ROWS,)
+        assert output_heads is False
+        return torch.zeros(1, ROWS, HEADS * DIM, dtype=q.dtype)
+
+    result, state, plans, _, receipts = _run_block(
+        monkeypatch,
+        Config(exact=False, backend="sol", dense_evaluations=1, dense_layers=0),
+        sparse_impl=sparse_impl,
+        dense_impl=dense_impl,
+    )
+
+    assert result.shape == (1, ROWS, HEADS * DIM)
+    assert len(dense_calls) == 1
+    assert dense_calls[0][4] is plans[0]
+    assert [(p.implementation_profile, p.numerical_route) for p in plans] == [(
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )]
+    assert receipts[0][3][4:6] == (
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    assert state.dense_calls == 1
+    assert state.external_mixed_weighted_measure_calls == 1
+    assert state.external_mixed_weighted_measure_kv_rows == ROWS
+
+
+def test_weighted_kernel_unavailable_rebinds_dense_fallback_receipt(monkeypatch):
+    dense_calls = []
+
+    def sparse_impl(*args, **kwargs):
+        raise sparse.KernelUnavailable("test-unavailable")
+
+    def dense_impl(q, k, v, heads, plan, *, scale=None, output_heads=False):
+        dense_calls.append((k.shape[2], plan, output_heads))
+        return torch.zeros(1, ROWS, HEADS * DIM, dtype=q.dtype)
+
+    result, state, plans, _, receipts = _run_block(
+        monkeypatch,
+        Config(exact=False, backend="sol", dense_evaluations=0, dense_layers=0),
+        sparse_impl=sparse_impl,
+        dense_impl=dense_impl,
+    )
+
+    assert result.shape == (1, ROWS, HEADS * DIM)
+    assert len(plans) == 2
+    assert (plans[0].implementation_profile, plans[0].numerical_route) == (
+        weighted_measure.SPARSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.SPARSE_NUMERICAL_ROUTE,
+    )
+    assert (plans[1].implementation_profile, plans[1].numerical_route) == (
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    assert dense_calls == [(ROWS, plans[1], False)]
+    assert receipts[0][3][4:6] == (
+        weighted_measure.DENSE_IMPLEMENTATION_PROFILE,
+        weighted_measure.DENSE_NUMERICAL_ROUTE,
+    )
+    assert state.external_mixed_weighted_measure_calls == 1
+    assert state.external_mixed_weighted_measure_q_rows == ROWS
+    assert state.external_mixed_weighted_measure_kv_rows == ROWS
+    assert state.external_mixed_measure_calls == 0
+    assert state.fallbacks["kernel_unavailable:test-unavailable"] == 1
+
+
+def test_generic_weighted_measure_does_not_require_vdn_external_sequence(monkeypatch):
+    calls = []
+
+    def sparse_impl(q, k, v, prefix, config, state, **kwargs):
+        calls.append((prefix, k.shape[2], kwargs["exact_k_blocks"]))
+        state.sparse_calls += 1
+        return torch.zeros(1, ROWS, HEADS * DIM, dtype=q.dtype)
+
+    def dense_impl(*args, **kwargs):
+        raise AssertionError("generic all-row weighted route unexpectedly fell back to dense")
+
+    result, state, plans, _, _ = _run_block(
+        monkeypatch,
+        Config(exact=False, backend="sol", dense_evaluations=0, dense_layers=0),
+        sparse_impl=sparse_impl,
+        dense_impl=dense_impl,
+        include_external=False,
+    )
+
+    assert result.shape == (1, ROWS, HEADS * DIM)
+    assert calls == [(10, ROWS, (0, 3))]
+    assert plans[0].numerical_route == weighted_measure.SPARSE_NUMERICAL_ROUTE
+    assert state.external_mixed_weighted_measure_calls == 1

--- a/tests/test_weighted_sm120_gpu.py
+++ b/tests/test_weighted_sm120_gpu.py
@@ -1,0 +1,159 @@
+"""Real-SM120 numerical acceptance for weighted Sol-Attn.
+
+These tests deliberately execute the packaged CuTe kernel. CPU CI only verifies
+that they collect; release acceptance requires running them on an SM120 GPU.
+"""
+
+import math
+
+import pytest
+import torch
+
+from sol_h3 import sparse
+
+
+_SCALE = 128 ** -0.5
+_BLOCK = 64
+
+
+def _sm120_kernel():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("requires real SM120")
+    kernel = sparse.load_kernel(torch.device("cuda"))
+    assert kernel.backend_name == "cute_sm120"
+    return kernel
+
+
+def _weighted_dense_reference(q, k, v, key_bias):
+    """Independent dense natural-log key-measure reference in FP32."""
+    logits = torch.einsum("bqhd,bkhd->bhqk", q.float(), k.float()) * _SCALE
+    logits = logits + key_bias.view(1, 1, 1, -1)
+    probs = logits.softmax(dim=-1)
+    return torch.einsum("bhqk,bkhd->bqhd", probs, v.float()).bfloat16()
+
+
+def _forced_sparse_reference(q, k, v, key_bias, sink_start, sink_tokens):
+    """Independent tau=inf compressed-softmax oracle.
+
+    Sol-Attn keeps ordinal-neighbour and sink-overlapping blocks exact. Other
+    blocks use the BF16 K centroid plus BF16 V sum, represented as one key with
+    log(block_rows) mass. This mirrors the mathematical sparse route without
+    calling the production kernel or its preprocessing implementation.
+    """
+    sink_begin = sink_start // _BLOCK
+    sink_end = (sink_start + sink_tokens + _BLOCK - 1) // _BLOCK
+    outputs = []
+
+    for q_start in range(0, q.shape[1], _BLOCK):
+        q_block = q_start // _BLOCK
+        keys = []
+        values = []
+        log_masses = []
+        biases = []
+
+        for k_start in range(0, k.shape[1], _BLOCK):
+            k_block = k_start // _BLOCK
+            kb = k[:, k_start:k_start + _BLOCK]
+            vb = v[:, k_start:k_start + _BLOCK]
+            rows = kb.shape[1]
+            exact = abs(q_block - k_block) <= 1 or sink_begin <= k_block < sink_end
+
+            if exact:
+                keys.append(kb.float())
+                values.append(vb.float())
+                log_masses.extend([0.0] * rows)
+                biases.append(key_bias[k_start:k_start + rows].float())
+            else:
+                keys.append(kb.float().mean(1, keepdim=True).bfloat16().float())
+                values.append(
+                    vb.float().sum(1, keepdim=True).bfloat16().float() / float(rows)
+                )
+                log_masses.append(math.log(float(rows)))
+                # The test places non-unit key measure only in the exact sink.
+                # Approximate blocks therefore carry unit measure.
+                biases.append(torch.zeros(1, device=q.device, dtype=torch.float32))
+
+        keys_cat = torch.cat(keys, dim=1)
+        values_cat = torch.cat(values, dim=1)
+        logits = torch.einsum(
+            "bqhd,bkhd->bhqk", q[:, q_start:q_start + _BLOCK].float(), keys_cat
+        ) * _SCALE
+        logits = logits + torch.tensor(
+            log_masses, device=q.device, dtype=torch.float32
+        ).view(1, 1, 1, -1)
+        logits = logits + torch.cat(biases).view(1, 1, 1, -1)
+        outputs.append(
+            torch.einsum("bhqk,bkhd->bqhd", logits.softmax(dim=-1), values_cat)
+        )
+
+    return torch.cat(outputs, dim=1).bfloat16()
+
+
+@pytest.mark.gpu
+def test_real_sm120_weighted_all_selected_matches_dense_and_changes_output():
+    """Compile/execute the weighted specialization and verify log-bias units."""
+    kernel = _sm120_kernel()
+    torch.manual_seed(211)
+    q = torch.randn(1, 65, 2, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 193, 2, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    key_bias = torch.zeros(193, device="cuda", dtype=torch.float32)
+    key_bias[:64] = math.log(0.25)
+    key_bias[64:128] = math.log(2.0)
+    key_bias[128:] = math.log(0.6)
+
+    with torch.inference_mode():
+        got = kernel(
+            q,
+            k,
+            v,
+            tau=float("inf"),
+            sink_start=0,
+            sink_tokens=k.shape[1],
+            key_bias=key_bias,
+        )
+        want = _weighted_dense_reference(q, k, v, key_bias)
+        metrics = sparse.error_metrics(got, want)
+        assert sparse.arithmetic_gate_passes(metrics), metrics
+
+        plain = kernel(
+            q,
+            k,
+            v,
+            tau=float("inf"),
+            sink_start=0,
+            sink_tokens=k.shape[1],
+        )
+        assert not torch.equal(got, plain)
+
+
+@pytest.mark.gpu
+def test_real_sm120_weighted_exact_sink_preserves_sparse_tail():
+    """Non-unit key measure stays exact while unrelated far blocks stay sparse."""
+    kernel = _sm120_kernel()
+    torch.manual_seed(223)
+    q = torch.randn(1, 65, 2, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 449, 2, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+
+    sink_start = 64
+    sink_tokens = 128
+    key_bias = torch.zeros(449, device="cuda", dtype=torch.float32)
+    key_bias[64:128] = math.log(0.4)
+    key_bias[128:192] = math.log(1.8)
+
+    with torch.inference_mode():
+        got = kernel(
+            q,
+            k,
+            v,
+            tau=float("inf"),
+            sink_start=sink_start,
+            sink_tokens=sink_tokens,
+            key_bias=key_bias,
+        )
+        want = _forced_sparse_reference(
+            q, k, v, key_bias, sink_start=sink_start, sink_tokens=sink_tokens
+        )
+        metrics = sparse.error_metrics(got, want)
+        assert sparse.arithmetic_gate_passes(metrics), metrics

--- a/tests/test_weighted_sm120_host.py
+++ b/tests/test_weighted_sm120_host.py
@@ -1,0 +1,77 @@
+from contextlib import nullcontext
+
+import torch
+
+from sol_h3._vendor.sol_attn import interface
+
+
+def test_sm120_weighted_cache_separates_specialization_and_rebinds_bias_buffer(monkeypatch):
+    from sol_h3._vendor.sol_attn import preprocess
+
+    monkeypatch.setattr(torch.cuda, "device", lambda _: nullcontext())
+    monkeypatch.setattr(interface, "_stream", lambda _: None)
+    monkeypatch.setattr(interface, "_to_cute_tensors", lambda tensors: tensors)
+    monkeypatch.setattr(interface, "_compiled", {})
+
+    thresholds = []
+
+    def prepare(q, k, v, **kwargs):
+        blocks = (k.shape[1] + 63) // 64
+        kc = torch.empty(1, blocks, q.shape[2], q.shape[3])
+        vc = torch.empty_like(kc)
+        threshold = torch.empty(1, (q.shape[1] + 63) // 64, q.shape[2])
+        thresholds.append(threshold)
+        return kc, vc, threshold
+
+    monkeypatch.setattr(preprocess, "prepare", prepare)
+
+    compiles = []
+    launches = []
+
+    def compile_(key, tensors, scale, start, end, stream, key_bias_enabled):
+        compiles.append((key, key_bias_enabled, start, end))
+
+        def compiled(*args, **kwargs):
+            launches.append(args)
+            args[3].copy_(args[0])
+
+        interface._compiled[key] = compiled
+        return compiled, tensors
+
+    monkeypatch.setattr(interface, "_compile_sm120", compile_)
+
+    q = torch.zeros(1, 65, 2, 128, dtype=torch.bfloat16)
+    k = torch.zeros(1, 202, 2, 128, dtype=q.dtype)
+    v = torch.zeros_like(k)
+    bias_a = torch.linspace(-1.0, 0.0, 202, dtype=torch.float32).contiguous()
+    bias_b = torch.linspace(-2.0, 0.0, 202, dtype=torch.float32).contiguous()
+
+    common = dict(
+        arch=(12, 0),
+        scale=128 ** -0.5,
+        tau=1.0,
+        thresh_type="diag",
+        kv_splits=1,
+        sink_tokens=192,
+        sink_start=0,
+        valid_tokens=65,
+    )
+    interface._sol_attn_cute(q, k, v, key_bias=bias_a, **common)
+    interface._sol_attn_cute(q, k, v, key_bias=bias_b, **common)
+    interface._sol_attn_cute(q, k, v, key_bias=None, **common)
+    interface._sol_attn_cute(q, k, v, key_bias=None, **common)
+
+    # Biased and unweighted kernels are different CuTe specializations, but
+    # changing only values in an identically laid-out immutable bias vector
+    # reuses the compiled weighted descriptor and passes the current buffer.
+    assert [(enabled, start, end) for _, enabled, start, end in compiles] == [
+        (True, 0, 3),
+        (False, 0, 3),
+    ]
+    assert launches[0][7] is bias_a
+    assert launches[1][7] is bias_b
+    # No-bias specialization never needs a second O(T) allocation; its unused
+    # tensor slot is the already-live threshold buffer for that invocation.
+    assert launches[2][7] is thresholds[2]
+    assert launches[3][7] is thresholds[3]
+    assert all(args[3].shape == q.shape for args in launches)

--- a/tests/test_zero_copy_bthd.py
+++ b/tests/test_zero_copy_bthd.py
@@ -70,7 +70,7 @@ def test_sparse_bridge_preserves_comfy_strided_views_and_calibrates_per_layout(m
     monkeypatch.setattr(
         sparse,
         "_dense_reference",
-        lambda q, k, v, dense_attention: torch.zeros(
+        lambda q, k, v, dense_attention, key_bias=None: torch.zeros(
             (q.shape[0], q.shape[2], q.shape[1], q.shape[3]),
             dtype=q.dtype,
             device=q.device,

--- a/tools/rectangular_sm120.patch
+++ b/tools/rectangular_sm120.patch
@@ -1,13 +1,19 @@
 diff --git a/sol_h3/_vendor/sol_attn/interface.py b/sol_h3/_vendor/sol_attn/interface.py
-index c49f1ad..951b93c 100644
+index c49f1ad..e68660b 100644
 --- a/sol_h3/_vendor/sol_attn/interface.py
 +++ b/sol_h3/_vendor/sol_attn/interface.py
-@@ -1,3 +1,4 @@
+@@ -1,8 +1,10 @@
 +# Modified by ComfyUI-Sol-H3: rectangular SM120 Q/KV geometry; see tools/rectangular_sm120.patch.
  """Public Sol-Attn interface."""
  
  from __future__ import annotations
-@@ -28,9 +29,10 @@ def _validate_inputs(
+ 
+ import functools
++import math
+ 
+ import torch
+ 
+@@ -28,9 +30,10 @@ def _validate_inputs(
      sink_tokens=0,
      sink_start=None,
  ):
@@ -21,7 +27,7 @@ index c49f1ad..951b93c 100644
          raise ValueError("Sol-Attn requires T > 0 and head dimension 128")
      if any(x.dtype != torch.bfloat16 for x in (q, k, v)):
          raise TypeError("q, k, and v must use torch.bfloat16")
-@@ -47,15 +49,15 @@ def _validate_inputs(
+@@ -47,15 +50,15 @@ def _validate_inputs(
          raise ValueError("thresh_type must be 'diag' or 'exact'")
      if not isinstance(sink_tokens, int):
          raise TypeError("sink_tokens must be an integer")
@@ -43,7 +49,28 @@ index c49f1ad..951b93c 100644
      return tuple(torch.cuda.get_device_capability(q.device))
  
  
-@@ -236,7 +238,8 @@ def _sol_attn_cute(
+@@ -198,12 +201,13 @@ def _compile_sm120(
+     sink_start_block,
+     sink_end_block,
+     stream,
++    key_bias_enabled,
+ ):
+     import cutlass.cute as cute
+ 
+     from .sm120 import make_kernel
+ 
+-    operator = make_kernel()
++    operator = make_kernel(key_bias_enabled=key_bias_enabled)
+     args = _to_cute_tensors(tensors)
+     compiled = cute.compile(
+         operator,
+@@ -231,12 +235,14 @@ def _sol_attn_cute(
+     sink_tokens,
+     sink_start,
+     valid_tokens=None,
++    key_bias=None,
+ ):
+     from .preprocess import prepare
  
      batch, capacity_tokens, heads, _ = q.shape
      tokens = capacity_tokens if valid_tokens is None else int(valid_tokens)
@@ -53,7 +80,7 @@ index c49f1ad..951b93c 100644
  
      with torch.cuda.device(q.device):
          kc, vc, threshold = prepare(
-@@ -247,8 +250,9 @@ def _sol_attn_cute(
+@@ -247,8 +253,9 @@ def _sol_attn_cute(
              tau=tau,
              thresh_type=thresh_type,
              valid_tokens=tokens,
@@ -64,12 +91,15 @@ index c49f1ad..951b93c 100644
          lse = torch.empty(
              (batch, capacity_tokens, heads),
              device=q.device,
-@@ -259,12 +263,12 @@ def _sol_attn_cute(
+@@ -259,12 +266,15 @@ def _sol_attn_cute(
          # supply views into an interleaved packed QKV buffer; never reuse a compiled contiguous
          # descriptor for a strided view (or vice versa).
          layout_key = tuple(tuple(int(s) for s in x.stride()) for x in (q, k, v))
 -        key = (q.device.index, arch, batch, capacity_tokens, heads, kv_splits, layout_key)
-+        key = (q.device.index, arch, batch, capacity_tokens, k.shape[1], heads, kv_splits, layout_key)
++        key = (
++            q.device.index, arch, batch, capacity_tokens, k.shape[1], heads, kv_splits,
++            layout_key, key_bias is not None,
++        )
  
          if arch == (9, 0):
              if sink_tokens:
@@ -79,7 +109,7 @@ index c49f1ad..951b93c 100644
                      sink_start,
                      sink_tokens,
                  )
-@@ -308,7 +312,7 @@ def _sol_attn_cute(
+@@ -308,7 +318,7 @@ def _sol_attn_cute(
              )
          elif arch in ((10, 0), (10, 3)):
              sink_start_block, sink_end_block = _sink_block_range(
@@ -88,7 +118,7 @@ index c49f1ad..951b93c 100644
                  sink_start,
                  sink_tokens,
              )
-@@ -338,7 +342,7 @@ def _sol_attn_cute(
+@@ -338,11 +348,12 @@ def _sol_attn_cute(
              )
          else:
              sink_start_block, sink_end_block = _sink_block_range(
@@ -97,16 +127,48 @@ index c49f1ad..951b93c 100644
                  sink_start,
                  sink_tokens,
              )
-@@ -449,6 +453,8 @@ def sol_attn(
+-            tensors = [q, k, v, output, kc, vc, threshold, lse]
++            key_bias_arg = key_bias if key_bias is not None else threshold
++            tensors = [q, k, v, output, kc, vc, threshold, key_bias_arg, lse]
+             compiled = _compiled.get(key)
+             if compiled is None:
+                 compiled, args = _compile_sm120(
+@@ -352,6 +363,7 @@ def _sol_attn_cute(
+                     sink_start_block,
+                     sink_end_block,
+                     stream,
++                    key_bias is not None,
+                 )
+             else:
+                 args = _to_cute_tensors(tensors)
+@@ -430,6 +442,7 @@ def sol_attn(
+     sink_tokens: int = 0,
+     sink_start: int | None = None,
+     compile_bucket_size: int | None = None,
++    key_bias: torch.Tensor | None = None,
+ ) -> torch.Tensor:
+     """Compute noncausal Sol-Attn for innermost-contiguous BF16 BTHD tensors.
+ 
+@@ -449,6 +462,18 @@ def sol_attn(
      if kv_splits not in (1, 2, 4):
          raise ValueError("kv_splits must be 1, 2, or 4")
      backend = _backend_for_arch(arch)
++    if key_bias is not None:
++        if backend != "cute_sm120":
++            raise ValueError("key_bias is currently supported by cute_sm120 only")
++        if (not torch.is_tensor(key_bias) or key_bias.ndim != 1
++                or key_bias.shape[0] != k.shape[1] or key_bias.device != q.device
++                or key_bias.dtype != torch.float32 or not key_bias.is_contiguous()):
++            raise ValueError("key_bias must be contiguous float32 with one natural-log value per K/V row")
++        weighted_scale = q.shape[-1] ** -0.5 if scale is None else float(scale)
++        if not math.isfinite(weighted_scale) or weighted_scale <= 0.0:
++            raise ValueError("weighted Sol-Attn requires a finite positive attention scale")
 +    if q.shape[1] != k.shape[1] and backend != "cute_sm120":
 +        raise ValueError("Rectangular attention currently requires cute_sm120")
      valid_tokens = q.shape[1]
      if compile_bucket_size is not None:
          if backend != "cute_sm100":
-@@ -476,7 +482,7 @@ def sol_attn(
+@@ -476,7 +501,7 @@ def sol_attn(
              sink_start=sink_start,
          )
  
@@ -115,6 +177,14 @@ index c49f1ad..951b93c 100644
      return _sol_attn_cute(
          q,
          k,
+@@ -489,6 +514,7 @@ def sol_attn(
+         sink_tokens=sink_tokens,
+         sink_start=sink_start,
+         valid_tokens=valid_tokens,
++        key_bias=key_bias,
+     )
+ 
+ 
 diff --git a/sol_h3/_vendor/sol_attn/preprocess.py b/sol_h3/_vendor/sol_attn/preprocess.py
 index cad8d2a..ace53ba 100644
 --- a/sol_h3/_vendor/sol_attn/preprocess.py
@@ -208,8 +278,26 @@ index cad8d2a..ace53ba 100644
              return_q_bar=return_q_bar,
          )
          if return_q_bar:
+diff --git a/sol_h3/_vendor/sol_attn/sm120/kernel.py b/sol_h3/_vendor/sol_attn/sm120/kernel.py
+index 1af031b..2128eb4 100644
+--- a/sol_h3/_vendor/sol_attn/sm120/kernel.py
++++ b/sol_h3/_vendor/sol_attn/sm120/kernel.py
+@@ -8,11 +8,13 @@ def make_kernel(
+     debug_route_trace: bool = False,
+     prefetch_first_exact_k: bool = True,
+     prefetch_next_route_k: bool = True,
++    key_bias_enabled: bool = False,
+ ):
+     return SolAttnForwardSm120(
+         debug_route_trace=debug_route_trace,
+         prefetch_first_exact_k=prefetch_first_exact_k,
+         prefetch_next_route_k=prefetch_next_route_k,
++        key_bias_enabled=key_bias_enabled,
+     )
+ 
+ 
 diff --git a/sol_h3/_vendor/sol_attn/sm120/mainloop.py b/sol_h3/_vendor/sol_attn/sm120/mainloop.py
-index e96fa06..fe77b43 100644
+index e96fa06..55310f9 100644
 --- a/sol_h3/_vendor/sol_attn/sm120/mainloop.py
 +++ b/sol_h3/_vendor/sol_attn/sm120/mainloop.py
 @@ -1,4 +1,4 @@
@@ -218,7 +306,31 @@ index e96fa06..fe77b43 100644
  # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
  # SPDX-License-Identifier: Apache-2.0
  """Fused Sol-Attn forward kernel for GeForce Blackwell SM120.
-@@ -96,7 +96,7 @@ class SolAttnForwardSm120:
+@@ -45,6 +45,7 @@ class SolAttnForwardSm120:
+         debug_route_trace: bool = False,
+         prefetch_first_exact_k: bool = True,
+         prefetch_next_route_k: bool = True,
++        key_bias_enabled: bool = False,
+     ):
+         self.dtype = cutlass.BFloat16
+         self.acc_dtype = cutlass.Float32
+@@ -56,6 +57,7 @@ class SolAttnForwardSm120:
+         self.debug_route_trace = debug_route_trace
+         self.prefetch_first_exact_k = prefetch_first_exact_k
+         self.prefetch_next_route_k = prefetch_next_route_k
++        self.key_bias_enabled = key_bias_enabled
+ 
+     @cute.kernel
+     def kernel(
+@@ -67,6 +69,7 @@ class SolAttnForwardSm120:
+         mKC: cute.Tensor,
+         mVC: cute.Tensor,
+         mThreshold: cute.Tensor,
++        mKeyBias: cute.Tensor,
+         mLSE: cute.Tensor,
+         tma_atom_Q: cute.CopyAtom,
+         tma_atom_K: cute.CopyAtom,
+@@ -96,7 +99,7 @@ class SolAttnForwardSm120:
          num_blocks = mKC.shape[0]
          num_route_groups = cute.ceil_div(num_blocks, N)
          q_start = q_tile_idx * M
@@ -227,3 +339,63 @@ index e96fa06..fe77b43 100644
          if q_len > M:
              q_len = cutlass.Int32(M)
          threshold = cutlass.Float32(
+@@ -611,6 +614,11 @@ class SolAttnForwardSm120:
+                 if block_len > N:
+                     block_len = cutlass.Int32(N)
+                 mask_exact_scores(tSrS, tScS, block_len, q_len)
++                if cutlass.const_expr(self.key_bias_enabled):
++                    add_exact_key_bias(
++                        tSrS, tScS, mKeyBias, exact_block, block_len, q_len,
++                        cutlass.Float32(1.4426950408889634) / scale_softmax_log2e,
++                    )
+                 row_scale = online_softmax(
+                     tSrS, max_m, sum_m, scale_softmax_log2e
+                 )
+@@ -698,6 +706,7 @@ class SolAttnForwardSm120:
+         kc: cute.Tensor,
+         vc: cute.Tensor,
+         threshold: cute.Tensor,
++        key_bias: cute.Tensor,
+         lse: cute.Tensor,
+         softmax_scale: cutlass.Float32,
+         sink_start_block: cutlass.Int32,
+@@ -872,6 +881,7 @@ class SolAttnForwardSm120:
+             tma_tensor_KC,
+             tma_tensor_VC,
+             threshold,
++            key_bias,
+             lse_target,
+             tma_atom_Q,
+             tma_atom_K,
+@@ -1034,6 +1044,31 @@ def mask_exact_scores(
+                 scores_mn[m, n] = -cutlass.Float32.inf
+ 
+ 
++@cute.jit
++def add_exact_key_bias(
++    scores: cute.Tensor,
++    coords: cute.Tensor,
++    key_bias: cute.Tensor,
++    exact_block: cutlass.Int32,
++    block_len: cutlass.Int32,
++    q_len: cutlass.Int32,
++    inv_softmax_scale: cutlass.Float32,
++):
++    """Add natural-log key measure as b/scale to valid exact raw QK scores."""
++    scores_mn = layout_utils.reshape_acc_to_mn(scores)
++    coords_mn = layout_utils.reshape_acc_to_mn(coords)
++    for m in cutlass.range_constexpr(cute.size(scores_mn, mode=[0])):
++        valid_row = coords_mn[m, 0][0] < q_len
++        for n in cutlass.range_constexpr(cute.size(scores_mn, mode=[1])):
++            local_col = coords_mn[m, n][1]
++            if valid_row and local_col < block_len:
++                absolute_col = exact_block * cutlass.Int32(N) + local_col
++                scores_mn[m, n] = (
++                    cutlass.Float32(scores_mn[m, n])
++                    + cutlass.Float32(key_bias[absolute_col]) * inv_softmax_scale
++                )
++
++
+ @cute.jit
+ def online_softmax(
+     scores: cute.Tensor,

--- a/tools/vendor_sol_attn.py
+++ b/tools/vendor_sol_attn.py
@@ -66,10 +66,10 @@ def main():
         records[path] = {'upstream_sha256': hashlib.sha256(raw).hexdigest(),
                          'packaged_sha256': hashlib.sha256(packaged).hexdigest()}
         if packaged != relocate(raw, path):
-            records[path]['modifications'] = ['rectangular-sm120-v2']
+            records[path]['modifications'] = ['rectangular-sm120-v3']
     manifest = {'source': 'sana-sol-engine', 'repository': 'https://github.com/xmarre/Sana',
                 'branch': 'sol-engine', 'revision': REVISION, 'subtree': SUBTREE,
-                'transformation': 'relative-imports-v1; rectangular-sm120-v2 (tools/rectangular_sm120.patch)',
+                'transformation': 'relative-imports-v1; rectangular-sm120-v3 (tools/rectangular_sm120.patch)',
                 'packaged_patch_sha256': hashlib.sha256((ROOT / 'tools/rectangular_sm120.patch').read_bytes()).hexdigest(),
                 'files': records}
     (ROOT / 'sol_h3' / 'sol_manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')


### PR DESCRIPTION
## Summary

Implement the Sol-H3 provider side of the generic `attention_measure_v1` design for heterogeneous MiniMax-H3 Mixed-Grid attention.

Unlike the released legacy representative-K/V compatibility path, this route keeps every Q/K/V row and represents the protected-prefix spatial measure as an additive natural-log key-score bias. Non-unit-measure K blocks are merged into Sol-H3's exact K sink, so biased keys never enter the approximate centroid branch.

## Provider ownership and cache safety

- Registers a model-local `comfy.sol_h3.sm120` measure capability when the companion Core contract is available.
- Refreshes Sol-H3's own owner generation on a new Sol-H3 installation without mutating a shallow-cloned source registry.
- Rejects a foreign capability already claiming the same provider identity.
- Binds plan identity to measure digest, concrete preprocessing chain, model-owner generation, layout/device/dtype, exact K sink and numerical route.
- Revalidates the live H3 layout, optional API-2 external-sequence geometry and merged exact-K range on every cached-plan hit. The cache may reuse the immutable O(T) measure buffer for identical geometry, but stale/foreign geometry or malformed sink state cannot bypass Core validation.
- Preprocessing identity distinguishes immutable stateless function semantics from stateful callable ownership: recreated closure/default-free transforms reuse a stable code fingerprint, while stateful owners receive weak-reference-bound generations so object-address reuse cannot alias a stale plan. Non-weakrefable stateful owners fail closed.
- Keeps the generic contract independent of VDN; VDN API 2 is cross-checked when present. The released legacy representative-K/V contract still requires its external-sequence contract.

## Numerical routes

The same immutable O(T) key-measure buffer is shared across two separately bound plans:

- `weighted_exact_blocks_v1` / `sol_h3_sm120_weighted_exact_blocks` for the SM120 sparse route;
- `dense_exact_v1` / `sol_h3_weighted_dense_exact` for dense warmup or a kernel-unavailable fallback.

Receipts report the route that actually executed. Dense fallback therefore cannot attest the sparse implementation profile.

Full-domain attention preprocessing runs once before either route. Weighted mode never enters the legacy `reduce_kv` path.

## SM120 kernel

The vendored Sana SM120 path accepts an optional contiguous FP32 natural-log `key_bias` vector. Weighted and unweighted CuTe kernels have separate specialization keys. In each exact K block, invalid tail scores are masked first, then valid raw QK scores receive `bias / scale`, then the existing online softmax applies `scale * log2(e)`. This adds the requested natural-log bias exactly once without changing the mainloop's existing running-max units.

The bias is read only for valid logical K columns. No-bias calls preserve the existing route and use no extra O(T) allocation.

The production calibration reference now casts only its additive SDPA mask view to the BF16 query dtype. The authoritative contiguous FP32 natural-log `key_bias` remains unchanged and is still passed to the CuTe weighted specialization. This is required because PyTorch CUDA SDPA rejects an FP32 floating mask against BF16 Q/K/V.

## Production evidence and current GPU gate

A real RTX PRO 6000 Blackwell / SM120 production run reached the weighted Mixed-Grid route before failing: Sol-H3 reported **52 `external_mixed_weighted_measure_calls` and 2,337,816 weighted Q rows / 2,337,816 weighted KV rows**. This closes the earlier activation ambiguity: Flow is requesting the weighted route and Sol-H3 is consuming it.

That run then failed inside Sol-H3's independent PyTorch SDPA calibration reference with `RuntimeError: invalid dtype for bias - should match query's dtype`. Q/K/V were BF16 while the contract-correct key measure was FP32. This head fixes exactly that calibration-view mismatch without weakening or changing the FP32 public measure contract.

The same run also exposed that Sol-H3's backend-history policy still recognized only legacy three-field receipts, so valid weighted four-field receipts were logged as malformed. The policy now validates weighted receipt payloads against the actual dense/sparse implementation profile and numerical route, while preserving legacy receipts. Direct weighted Sol remains Spectrum actual-only by policy; accepting and validating its actual receipt does not promote the direct route to forecast-safe.

The production run therefore provides real weighted-route activation evidence, but **does not yet establish weighted SM120 numerical correctness**: execution stopped before the weighted all-selected CuTe arithmetic gate could complete. A same-workflow SM120 rerun is still required after this fix.

## Validation

The current one-commit head `de99a5cbe98acfac53cb5fe979c94b004b6acefc` is exactly one commit over `main`. Its clean mirror validation run `34579196844` passed all lanes:

- main CPU contract lane: **136 passed, 58 skipped, 2 warnings**;
- native interop lane: **39 passed, 1 skipped, 2 warnings**;
- Windows provenance lane: passed.

The new regressions explicitly prove that BF16 Q/K/V receive a BF16 SDPA calibration mask while the source key-bias tensor remains FP32, and that valid weighted dense/sparse/fallback receipts are accepted only when route/profile/schema agree. Malformed token aliases and profile/route mismatches fail closed.

The native-interop lane pins Core #16239 at `8406da920f9df19cbc14b76aef1bcd3dc4cf1119`, Spectrum #110 at `7f7b9b2d13476ea8b631de946ad48ce0fd33a8a5`, and the earlier Flow #30 weighted-activation head used by that lane. It includes a real Flow -> Core -> Sol contract test that constructs Flow's explicit weighted Mixed-Grid request, verifies matching semantic digests, API-2 geometry, exact-K block coverage, and the expected `log(0.5)` protected-prefix measure while preserving equal physical frame mass.

Focused cache tests prove that a previously bound plan cannot be reused across stale external geometry, changed H3 layout, a malformed bool/int-alias sink key, changed stateful preprocessing ownership, or recreated closure-bearing transforms. Recreated stateless transforms with identical immutable semantics deliberately keep the same preprocessing digest instead of churning the plan cache.

The head additionally includes dedicated `@pytest.mark.gpu` acceptance coverage for the actual weighted SM120 CuTe specialization:

- all-selected weighted CuTe vs an independent FP32 dense natural-log-bias reference, including proof that the bias changes the result;
- `tau=inf` sparse execution with the non-unit measure confined to exact sink blocks and unrelated distant K blocks remaining approximated, compared against an independent compressed-softmax oracle.

Those GPU tests intentionally skip without real SM120 hardware. Hosted CI therefore establishes structural/CPU compatibility only; it does **not** establish weighted CuTe numerical correctness.

## Spectrum scope

The design's first Spectrum implementation intentionally extends Spectrum's reviewed **Core-BSA** audit rather than installing a generic history policy that could bypass the existing cold-to-primed proof. Accordingly, Sol-H3's direct weighted provider receipt remains actual-only under Spectrum for this first implementation. That is not treated as evidence that the direct provider is forecast-safe; the coordinated production schedule gate applies to the reviewed Core-BSA route.

## Dependencies / acceptance boundary

Design: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/29

Flow weighted activation: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/30

Core generic contract: https://github.com/Comfy-Org/ComfyUI/pull/16239

Chunked BSA companion: https://github.com/Comfy-Org/comfy-kitchen/pull/171

VDN owner-bound epilogue: https://github.com/xmarre/ComfyUI-VDN-H3-Plus/pull/14

Spectrum completed-receipt/history companion: https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/pull/110

The cross-repository companions now exist structurally. This PR remains draft because a post-fix real-SM120 weighted rerun is still required, as are compiled kitchen `chunked_key_bias` validation, production CUDA receipt/history validation, decoded-media acceptance, and weighted performance measurements. CPU/source-order tests and non-SM120 collection do not establish those properties.